### PR TITLE
Viewport aggs PoC

### DIFF
--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -467,31 +467,17 @@ Renderer.prototype.refresh = function (timestamp) {
             const miny = (-1 + d.vertexOffset[1]) / d.vertexScale[1];
             const maxy = (1 + d.vertexOffset[1]) / d.vertexScale[1];
             for (let i = 0; i < d.numFeatures; i++) {
-                let avoid = false;
-                {
-                    const x = d.geom[2 * i + 0] * d.vertexScale[0] - d.vertexOffset[0];
-                    const y = d.geom[2 * i + 1] * d.vertexScale[1] - d.vertexOffset[1];
-                    if (x > 1 || x < -1 || y > 1 || y < -1) {
-                        avoid = true;
-                    }
-                }
                 const x = d.geom[2 * i + 0];
                 const y = d.geom[2 * i + 1];
                 if (x > minx && x < maxx && y > miny && y < maxy) {
                     const v = values[i];
                     if (!Number.isFinite(v)) {
-                        console.warn('asd');
+                        continue;
                     }
                     sum += v;
                     min = Math.min(min, v);
                     max = Math.max(max, v);
                     count++;
-                    if (avoid) {
-                        console.warn('err');
-                    }
-                } else if (!avoid) {
-                    console.warn('err2');
-                    debugger;
                 }
             }
             const metaColumn = drawMetadata.columns.find(c => c.name == column);

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -442,7 +442,7 @@ Renderer.prototype.refresh = function (timestamp) {
             freeTexUnit: 4,
             zoom: 1. / this._zoom
         };
-        styleExpr._preDraw(obj, gl);
+        styleExpr._preDraw(obj, gl, tiles);
 
         Object.keys(TID).forEach((name, i) => {
             gl.activeTexture(gl.TEXTURE0 + i);

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -444,8 +444,14 @@ Renderer.prototype.refresh = function (timestamp) {
             }
         ]
     };
-    let requiredColumns = ['amount'];
-    //console.log(tiles);
+    let requiredColumns = tiles.map(d => {
+        const widthRequirements = d.style._width._getDrawMetadataRequirements();
+        const colorRequirements = d.style._color._getDrawMetadataRequirements();
+        const strokeWidthRequirements = d.style._strokeWidth._getDrawMetadataRequirements();
+        const strokeColorRequirements = d.style._strokeWidth._getDrawMetadataRequirements();
+        return [widthRequirements, colorRequirements, strokeColorRequirements, strokeWidthRequirements].
+            reduce(schema.union, schema.IDENTITY);
+    }).reduce(schema.union, schema.IDENTITY).columns;
     const s = 1. / this._zoom;
     tiles.map(d => {
         requiredColumns.map(column => {
@@ -473,7 +479,7 @@ Renderer.prototype.refresh = function (timestamp) {
                 const y = d.geom[2 * i + 1];
                 if (x > minx && x < maxx && y > miny && y < maxy) {
                     const v = values[i];
-                    if (!Number.isFinite(v)){
+                    if (!Number.isFinite(v)) {
                         console.warn('asd');
                     }
                     sum += v;

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -497,13 +497,11 @@ Renderer.prototype._computeDrawMetadata = function () {
             }
         });
     });
-    tiles.map(d => {
-        requiredColumns.map(column => {
-            const metaColumn = drawMetadata.columns.find(c => c.name == column);
-            for (let i = 1; i < 1000; i++) {
-                metaColumn.accumHistogram[i] = metaColumn.accumHistogram[i - 1] + metaColumn.histogram[i];
-            }
-        });
+    requiredColumns.map(column => {
+        const metaColumn = drawMetadata.columns.find(c => c.name == column);
+        for (let i = 1; i < 1000; i++) {
+            metaColumn.accumHistogram[i] = metaColumn.accumHistogram[i - 1] + metaColumn.histogram[i];
+        }
     });
     return drawMetadata;
 };

--- a/src/core/style/expressions/animate.js
+++ b/src/core/style/expressions/animate.js
@@ -30,7 +30,7 @@ export default class Animate extends Expression {
     _postShaderCompile(program, gl) {
         this._uniformLocation = gl.getUniformLocation(program, `anim${this._uniformID}`);
     }
-    _preDraw(l, gl) {
+    _preDraw(drawMetadata, gl) {
         const time = Date.now();
         this.mix = (time - this.aTime) / (this.bTime - this.aTime);
         if (this.mix > 1.) {

--- a/src/core/style/expressions/blend.js
+++ b/src/core/style/expressions/blend.js
@@ -33,8 +33,8 @@ export default class Blend extends Expression {
         }
         this.inlineMaker = inline => `mix(${inline.a}, ${inline.b}, clamp(${inline.mix}, 0., 1.))`;
     }
-    _preDraw(l, gl) {
-        super._preDraw(l, gl);
+    _preDraw(...args) {
+        super._preDraw(...args);
         if (this.mix instanceof Animate && !this.mix.isAnimated()) {
             this.parent._replaceChild(this, this.b);
         }

--- a/src/core/style/expressions/buckets.js
+++ b/src/core/style/expressions/buckets.js
@@ -32,9 +32,8 @@ export default class Buckets extends Expression {
         const childSources = this.childrenNames.map(name => this[name]._applyToShaderSource(uniformIDMaker, propertyTIDMaker));
         let childInlines = {};
         childSources.map((source, index) => childInlines[this.childrenNames[index]] = source.inline);
-
         const funcName = `buckets${this.bucketUID}`;
-        const cmp = this.type == 'category' ? '==' : '<';
+        const cmp = this.input.type == 'category' ? '==' : '<';
         const elif = (_, index) =>
             `${index > 0 ? 'else' : ''} if (x${cmp}(${childInlines[`arg${index}`]})){
                 return ${index + 1}.;

--- a/src/core/style/expressions/category.js
+++ b/src/core/style/expressions/category.js
@@ -26,7 +26,7 @@ export default class Category extends Expression {
     _postShaderCompile(program, gl) {
         this._uniformLocation = gl.getUniformLocation(program, `cat${this._uniformID}`);
     }
-    _preDraw(l, gl) {
+    _preDraw(drawMetadata, gl) {
         const id = this._metadata.categoryIDs[this.expr];
         gl.uniform1f(this._uniformLocation, id);
     }

--- a/src/core/style/expressions/expression.js
+++ b/src/core/style/expressions/expression.js
@@ -61,8 +61,8 @@ export default class Expression {
      * Pre-rendering routine. Should establish related WebGL state as needed.
      * @param {*} l
      */
-    _preDraw(l, gl) {
-        this.childrenNames.forEach(name => this[name]._preDraw(l, gl));
+    _preDraw(...args) {
+        this.childrenNames.forEach(name => this[name]._preDraw(...args));
     }
 
     /**

--- a/src/core/style/expressions/expression.js
+++ b/src/core/style/expressions/expression.js
@@ -57,6 +57,11 @@ export default class Expression {
         this.childrenNames.forEach(name => this[name]._postShaderCompile(program, gl));
     }
 
+    _getDrawMetadataRequirements() {
+        // Depth First Search => reduce using union
+        return this._getChildren().map(child => child._getDrawMetadataRequirements()).reduce(schema.union, schema.IDENTITY);
+    }
+
     /**
      * Pre-rendering routine. Should establish related WebGL state as needed.
      * @param {*} l

--- a/src/core/style/expressions/float.js
+++ b/src/core/style/expressions/float.js
@@ -26,7 +26,7 @@ export default class Float extends Expression {
     _postShaderCompile(program, gl) {
         this._uniformLocation = gl.getUniformLocation(program, `float${this._uniformID}`);
     }
-    _preDraw(l, gl) {
+    _preDraw(drawMetadata, gl) {
         gl.uniform1f(this._uniformLocation, this.expr);
     }
     isAnimated() {

--- a/src/core/style/expressions/quantiles.js
+++ b/src/core/style/expressions/quantiles.js
@@ -1,5 +1,4 @@
 import Expression from './expression';
-import { implicitCast } from './utils';
 import { float } from '../functions';
 
 let quantilesUID = 0;

--- a/src/core/style/expressions/quantiles.js
+++ b/src/core/style/expressions/quantiles.js
@@ -1,0 +1,73 @@
+import Expression from './expression';
+import { implicitCast } from './utils';
+import { float } from '../functions';
+
+let quantilesUID = 0;
+
+export default class Quantiles extends Expression {
+    constructor(input, buckets) {
+        if (!Number.isFinite(buckets)) {
+            throw new Error('Quantiles() only accepts a fixed number of buckets');
+        }
+        let children = {
+            input
+        };
+        let breakpoints = [];
+        for (let i = 0; i < buckets - 1; i++) {
+            children[`arg${i}`] = float(i * 10);
+            breakpoints.push(children[`arg${i}`]);
+        }
+        super(children);
+        this.quantilesUID = quantilesUID++;
+        this.numCategories = buckets;
+        this.buckets = buckets;
+        this.breakpoints = breakpoints;
+    }
+    _compile(metadata) {
+        super._compile(metadata);
+        this.type = 'category';
+    }
+    _getDrawMetadataRequirements() {
+        return { columns: [this.input.name] };
+    }
+    _applyToShaderSource(uniformIDMaker, propertyTIDMaker) {
+        const childSources = this.childrenNames.map(name => this[name]._applyToShaderSource(uniformIDMaker, propertyTIDMaker));
+        let childInlines = {};
+        childSources.map((source, index) => childInlines[this.childrenNames[index]] = source.inline);
+        const funcName = `quantiles${this.quantilesUID}`;
+        const elif = (_, index) =>
+            `${index > 0 ? 'else' : ''} if (x<(${childInlines[`arg${index}`]})){
+            return ${index + 1}.;
+        }`;
+        const funcBody = this.breakpoints.map(elif).join('');
+        const preface = `float ${funcName}(float x){
+        ${funcBody}
+        return 0.;
+    }`;
+        return {
+            preface: childSources.map(s => s.preface).reduce((a, b) => a + b, '') + preface,
+            inline: `${funcName}(${childInlines.input})`
+        };
+    }
+    _preDraw(drawMetadata, gl) {
+        const column = drawMetadata.columns.find(c => c.name == this.input.name);
+        let i = 0;
+        const total = column.accumHistogram[999];
+        const r = Math.random();
+        let brs = [];
+        this.breakpoints.map((breakpoint, index) => {
+            for (i; i < 1000; i++) {
+                if (column.accumHistogram[i] >= (index + 1) / this.buckets * total) {
+                    break;
+                }
+            }
+            const br = i / 1000 * (column.max - column.min) + column.min;
+            brs.push(br);
+            breakpoint.expr = br;
+        });
+        if (r > 0.99) {
+            console.log(brs, column.min);
+        }
+        super._preDraw(drawMetadata, gl);
+    }
+}

--- a/src/core/style/expressions/ramp.js
+++ b/src/core/style/expressions/ramp.js
@@ -86,13 +86,13 @@ export default class Ramp extends Expression {
         this._keyMinLoc = gl.getUniformLocation(program, `keyMin${this._UID}`);
         this._keyWidthLoc = gl.getUniformLocation(program, `keyWidth${this._UID}`);
     }
-    _preDraw(l, gl,) {
-        this.input._preDraw(l, gl);
-        gl.activeTexture(gl.TEXTURE0 + l.freeTexUnit);
+    _preDraw(drawMetadata, gl) {
+        this.input._preDraw(drawMetadata, gl);
+        gl.activeTexture(gl.TEXTURE0 + drawMetadata.freeTexUnit);
         gl.bindTexture(gl.TEXTURE_2D, this.texture);
-        gl.uniform1i(this._texLoc, l.freeTexUnit);
+        gl.uniform1i(this._texLoc, drawMetadata.freeTexUnit);
         gl.uniform1f(this._keyMinLoc, (this.minKey));
         gl.uniform1f(this._keyWidthLoc, (this.maxKey) - (this.minKey));
-        l.freeTexUnit++;
+        drawMetadata.freeTexUnit++;
     }
 }

--- a/src/core/style/expressions/ramp.js
+++ b/src/core/style/expressions/ramp.js
@@ -13,8 +13,10 @@ export default class Ramp extends Expression {
      */
     constructor(input, palette, minKey, maxKey) {
         input = implicitCast(input);
-        minKey = implicitCast(minKey);
-        maxKey = implicitCast(maxKey);
+        if (minKey !== undefined) {
+            minKey = implicitCast(minKey);
+            maxKey = implicitCast(maxKey);
+        }
         var values = implicitCast(palette);
         super({ input: input });
         if (minKey === undefined) {

--- a/src/core/style/expressions/ramp.js
+++ b/src/core/style/expressions/ramp.js
@@ -86,7 +86,7 @@ export default class Ramp extends Expression {
         this._keyMinLoc = gl.getUniformLocation(program, `keyMin${this._UID}`);
         this._keyWidthLoc = gl.getUniformLocation(program, `keyWidth${this._UID}`);
     }
-    _preDraw(l, gl) {
+    _preDraw(l, gl,) {
         this.input._preDraw(l, gl);
         gl.activeTexture(gl.TEXTURE0 + l.freeTexUnit);
         gl.bindTexture(gl.TEXTURE_2D, this.texture);

--- a/src/core/style/expressions/top.js
+++ b/src/core/style/expressions/top.js
@@ -50,12 +50,12 @@ export default class Top extends Expression {
         this.property._postShaderCompile(program);
         this._texLoc = gl.getUniformLocation(program, `topMap${this._UID}`);
     }
-    _preDraw(l, gl, dataframes) {
-        this.property._preDraw(l, dataframes);
-        gl.activeTexture(gl.TEXTURE0 + l.freeTexUnit);
+    _preDraw(drawMetadata, gl) {
+        this.property._preDraw(drawMetadata);
+        gl.activeTexture(gl.TEXTURE0 + drawMetadata.freeTexUnit);
         gl.bindTexture(gl.TEXTURE_2D, this.texture);
-        gl.uniform1i(this._texLoc, l.freeTexUnit);
-        l.freeTexUnit++;
+        gl.uniform1i(this._texLoc, drawMetadata.freeTexUnit);
+        drawMetadata.freeTexUnit++;
     }
     //TODO _free
 }

--- a/src/core/style/expressions/top.js
+++ b/src/core/style/expressions/top.js
@@ -50,8 +50,8 @@ export default class Top extends Expression {
         this.property._postShaderCompile(program);
         this._texLoc = gl.getUniformLocation(program, `topMap${this._UID}`);
     }
-    _preDraw(l, gl) {
-        this.property._preDraw(l);
+    _preDraw(l, gl, dataframes) {
+        this.property._preDraw(l, dataframes);
         gl.activeTexture(gl.TEXTURE0 + l.freeTexUnit);
         gl.bindTexture(gl.TEXTURE_2D, this.texture);
         gl.uniform1i(this._texLoc, l.freeTexUnit);

--- a/src/core/style/expressions/utils.js
+++ b/src/core/style/expressions/utils.js
@@ -1,4 +1,5 @@
 import { float, category } from '../functions';
+import Expression from './expression';
 
 // To support literals (string and numeric) out of the box we need to cast them implicitly on constructors
 export function implicitCast(value) {
@@ -7,6 +8,9 @@ export function implicitCast(value) {
     }
     if (typeof value == 'string'){
         return category(value);
+    }
+    if (!( value instanceof Expression)){
+        throw new Error('value cannot be casted');
     }
     return value;
 }

--- a/src/core/style/expressions/utils.js
+++ b/src/core/style/expressions/utils.js
@@ -9,7 +9,7 @@ export function implicitCast(value) {
     if (typeof value == 'string'){
         return category(value);
     }
-    if (!( value instanceof Expression)){
+    if (!( value instanceof Expression) && !value.length){
         throw new Error('value cannot be casted');
     }
     return value;

--- a/src/core/style/expressions/viewportAggregation.js
+++ b/src/core/style/expressions/viewportAggregation.js
@@ -33,7 +33,7 @@ function generateViewportExpression(metadataPropertyName) {
             const column = drawMetadata.columns.find(c => c.name == this.property.name);
             this.value.expr = column[metadataPropertyName];
             if (Math.random() > 0.999) {
-                console.log(metadataPropertyName, this.property.name, column[metadataPropertyName]);
+                console.log(metadataPropertyName, this.property.name, column[metadataPropertyName], drawMetadata);
             }
             this.value._preDraw(drawMetadata, gl);
         }

--- a/src/core/style/expressions/viewportAggregation.js
+++ b/src/core/style/expressions/viewportAggregation.js
@@ -26,14 +26,14 @@ function generateViewportExpression(metadataPropertyName) {
         _getMinimumNeededSchema() {
             return this.property._getMinimumNeededSchema();
         }
-        _getDrawMetadataRequirements(){
-            return [this.property.name];
+        _getDrawMetadataRequirements() {
+            return { columns: [this.property.name] };
         }
         _preDraw(drawMetadata, gl) {
             const column = drawMetadata.columns.find(c => c.name == this.property.name);
             this.value.expr = column[metadataPropertyName];
-            if (Math.random() > 0.998) {
-                console.log(column[metadataPropertyName]);
+            if (Math.random() > 0.999) {
+                console.log(metadataPropertyName, this.property.name, column[metadataPropertyName]);
             }
             this.value._preDraw(drawMetadata, gl);
         }

--- a/src/core/style/expressions/viewportAggregation.js
+++ b/src/core/style/expressions/viewportAggregation.js
@@ -1,0 +1,24 @@
+import Expression from './expression';
+import { float } from '../functions';
+
+
+export default class ViewportMax extends Expression {
+    /**
+     * @jsapi
+     * @param {*} property
+     */
+    constructor(property) {
+        super({value: float(0)});
+        this.property = property;
+    }
+    _compile(metadata) {
+        super._compile(metadata);
+        this.type = 'float';
+        super.inlineMaker = inline => inline.value;
+    }
+    _preDraw(obj, gl, tile) {
+        this.value.expr = 3;
+        console.log(tile);
+        this.value._preDraw(obj, gl, tile);
+    }
+}

--- a/src/core/style/expressions/viewportAggregation.js
+++ b/src/core/style/expressions/viewportAggregation.js
@@ -8,17 +8,23 @@ export default class ViewportMax extends Expression {
      * @param {*} property
      */
     constructor(property) {
-        super({value: float(0)});
+        super({ value: float(0) });
         this.property = property;
     }
     _compile(metadata) {
         super._compile(metadata);
+        this.property._compile(metadata);
         this.type = 'float';
         super.inlineMaker = inline => inline.value;
     }
-    _preDraw(obj, gl, tile) {
-        this.value.expr = 3;
-        console.log(tile);
-        this.value._preDraw(obj, gl, tile);
+    _getMinimumNeededSchema() {
+        return this.property._getMinimumNeededSchema();
+    }
+    _preDraw(drawMetadata, gl) {
+        const column = drawMetadata.columns.find(c => c.name == this.property.name);
+        this.value.expr = column.avg;
+        console.log(column.avg);
+        //console.log(column.max);
+        this.value._preDraw(drawMetadata, gl);
     }
 }

--- a/src/core/style/expressions/viewportAggregation.js
+++ b/src/core/style/expressions/viewportAggregation.js
@@ -1,30 +1,41 @@
 import Expression from './expression';
 import { float } from '../functions';
 
+export const ViewportMax = generateViewportExpression('max');
+export const ViewportMin = generateViewportExpression('min');
+export const ViewportAvg = generateViewportExpression('avg');
+export const ViewportSum = generateViewportExpression('sum');
+export const ViewportCount = generateViewportExpression('count');
 
-export default class ViewportMax extends Expression {
-    /**
-     * @jsapi
-     * @param {*} property
-     */
-    constructor(property) {
-        super({ value: float(0) });
-        this.property = property;
-    }
-    _compile(metadata) {
-        super._compile(metadata);
-        this.property._compile(metadata);
-        this.type = 'float';
-        super.inlineMaker = inline => inline.value;
-    }
-    _getMinimumNeededSchema() {
-        return this.property._getMinimumNeededSchema();
-    }
-    _preDraw(drawMetadata, gl) {
-        const column = drawMetadata.columns.find(c => c.name == this.property.name);
-        this.value.expr = column.avg;
-        console.log(column.avg);
-        //console.log(column.max);
-        this.value._preDraw(drawMetadata, gl);
-    }
+function generateViewportExpression(metadataPropertyName) {
+    return class ViewportAggregattion extends Expression {
+        /**
+         * @jsapi
+         * @param {*} property
+         */
+        constructor(property) {
+            super({ value: float(0) });
+            this.property = property;
+        }
+        _compile(metadata) {
+            super._compile(metadata);
+            this.property._compile(metadata);
+            this.type = 'float';
+            super.inlineMaker = inline => inline.value;
+        }
+        _getMinimumNeededSchema() {
+            return this.property._getMinimumNeededSchema();
+        }
+        _getDrawMetadataRequirements(){
+            return [this.property.name];
+        }
+        _preDraw(drawMetadata, gl) {
+            const column = drawMetadata.columns.find(c => c.name == this.property.name);
+            this.value.expr = column[metadataPropertyName];
+            if (Math.random() > 0.998) {
+                console.log(column[metadataPropertyName]);
+            }
+            this.value._preDraw(drawMetadata, gl);
+        }
+    };
 }

--- a/src/core/style/expressions/zoom.js
+++ b/src/core/style/expressions/zoom.js
@@ -14,8 +14,8 @@ export default class Zoom extends Expression {
         this.type = 'float';
         super.inlineMaker = inline => inline.zoom;
     }
-    _preDraw(o, gl) {
-        this.zoom.expr = o.zoom;
-        this.zoom._preDraw(o, gl);
+    _preDraw(drawMetadata, gl) {
+        this.zoom.expr = drawMetadata.zoom;
+        this.zoom._preDraw(drawMetadata, gl);
     }
 }

--- a/src/core/style/functions.js
+++ b/src/core/style/functions.js
@@ -51,10 +51,11 @@ import { Mode } from './expressions/aggregation';
 import { ILinear } from './expressions/interpolators';
 import { Cubic } from './expressions/interpolators';
 
-import ViewportMax from './expressions/viewportAggregation';
+import { ViewportMax, ViewportMin, ViewportAvg, ViewportSum, ViewportCount }
+    from './expressions/viewportAggregation';
 
 
-// Expose clases as constructor functions
+// Expose classes as constructor functions
 export const floatMul = (...args) => new FloatMul(...args);
 export const floatDiv = (...args) => new FloatDiv(...args);
 export const floatAdd = (...args) => new FloatAdd(...args);
@@ -100,4 +101,9 @@ export const equals = (...args) => new Equals(...args);
 export const notEquals = (...args) => new NotEquals(...args);
 export const buckets = (...args) => new Buckets(...args);
 export const viewportMax = (...args) => new ViewportMax(...args);
+export const viewportMin = (...args) => new ViewportMin(...args);
+export const viewportAvg = (...args) => new ViewportAvg(...args);
+export const viewportSum = (...args) => new ViewportSum(...args);
+export const viewportCount = (...args) => new ViewportCount(...args);
+
 export { palettes };

--- a/src/core/style/functions.js
+++ b/src/core/style/functions.js
@@ -16,6 +16,7 @@ import Opacity from './expressions/opacity';
 import Top from './expressions/top';
 import XYZ from './expressions/xyz';
 import Zoom from './expressions/zoom';
+import Quantiles from './expressions/quantiles';
 
 // Unary ops
 import { Log } from './expressions/unary';
@@ -100,6 +101,7 @@ export const lessThanOrEqualTo = (...args) => new LessThanOrEqualTo(...args);
 export const equals = (...args) => new Equals(...args);
 export const notEquals = (...args) => new NotEquals(...args);
 export const buckets = (...args) => new Buckets(...args);
+export const quantiles = (...args) => new Quantiles(...args);
 export const viewportMax = (...args) => new ViewportMax(...args);
 export const viewportMin = (...args) => new ViewportMin(...args);
 export const viewportAvg = (...args) => new ViewportAvg(...args);

--- a/src/core/style/functions.js
+++ b/src/core/style/functions.js
@@ -51,6 +51,7 @@ import { Mode } from './expressions/aggregation';
 import { ILinear } from './expressions/interpolators';
 import { Cubic } from './expressions/interpolators';
 
+import ViewportMax from './expressions/viewportAggregation';
 
 
 // Expose clases as constructor functions
@@ -98,4 +99,5 @@ export const lessThanOrEqualTo = (...args) => new LessThanOrEqualTo(...args);
 export const equals = (...args) => new Equals(...args);
 export const notEquals = (...args) => new NotEquals(...args);
 export const buckets = (...args) => new Buckets(...args);
+export const viewportMax = (...args) => new ViewportMax(...args);
 export { palettes };


### PR DESCRIPTION
Initial PoC for https://github.com/CartoDB/renderer-prototype/issues/19

This PoC just supports numeric properties of point features.

Implemented expression functions: `viewportMax, viewportMin, viewportAvg, viewportSum, viewportCount`.

Now maps like `#eyJhIjoidHhfMDEyNV9jb3B5X2NvcHkiLCJiIjoiOGExNzRjNDUxMjE1Y2I4ZGNhOTAyNjRkZTM0MjYxNDA4N2M0ZWYwYyIsImMiOiJkbWFuemFuYXJlcy1kZWQxMyIsImQiOiJjYXJ0by1zdGFnaW5nLmNvbSIsImUiOiJ3aWR0aDogc3FydCgkYW1vdW50LzUwMDApKjEwKih6b29tKCkvNDAwMCswLjAxKSoxLjVcbmNvbG9yOiBvcGFjaXR5KGhzdigwLCAoKCRhbW91bnQvdmlld3BvcnRNYXgoJGFtb3VudCkpKSwxKSwgMC43KSIsImYiOnsibG5nIjoyLjE1NDI4NzU1NDQ3NjQ2ODQsImxhdCI6NDEuMzkyMzg2NTQxMjMwMzR9LCJnIjoxMy41MDk1Mzc3NTA3MjI0MTZ9` works.

Regarding the implementation, I've added a new internal-only method to the Expression base class. This new method returns the columns that have a viewport-dependant metadata usage. The `renderer` use this information to compute that data, and then it is passed to the `_preDraw` method to let the style expressions use it.

This PR includes quantiles() PoC: https://github.com/CartoDB/renderer-prototype/issues/11