### PR TITLE
Removes Mapbox access tokens from examples

### DIFF
--- a/example/basic/multi-layer.html
+++ b/example/basic/multi-layer.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/basic/single-layer.html
+++ b/example/basic/single-layer.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/index.js
+++ b/example/index.js
@@ -85,7 +85,6 @@ const texts = [
 const shipsStyle = 'width:    blend(1,2,near($day, (25*now()) %1000, 0, 10), cubic) *zoom()\ncolor:    setopacity(ramp(AVG($temp), tealrose, 0, 30), blend(0.005,1,near($day, (25*now()) %1000, 0, 10), cubic))';
 
 var mapboxgl = window.mapboxgl;
-mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
 var map = new mapboxgl.Map({
     container: 'map', // container id
     style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json', // stylesheet location

--- a/example/styling/cielab.2.html
+++ b/example/styling/cielab.2.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/cielab.html
+++ b/example/styling/cielab.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/default-all.html
+++ b/example/styling/default-all.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/float.html
+++ b/example/styling/float.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/floatMul.html
+++ b/example/styling/floatMul.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/hsv.html
+++ b/example/styling/hsv.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/now.html
+++ b/example/styling/now.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/opacity.html
+++ b/example/styling/opacity.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/rampCategoryAuto.html
+++ b/example/styling/rampCategoryAuto.html
@@ -29,7 +29,6 @@
     <div id='map'></div>
 </body>
 <script>
-    mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
     const map = new mapboxgl.Map({
         container: 'map',
         style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/rampCategoryBuckets.html
+++ b/example/styling/rampCategoryBuckets.html
@@ -29,7 +29,6 @@
     <div id='map'></div>
 </body>
 <script>
-    mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
     const map = new mapboxgl.Map({
         container: 'map',
         style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/rampCategoryTop.html
+++ b/example/styling/rampCategoryTop.html
@@ -29,7 +29,6 @@
     <div id='map'></div>
 </body>
 <script>
-    mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
     const map = new mapboxgl.Map({
         container: 'map',
         style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/rampNumericAuto.html
+++ b/example/styling/rampNumericAuto.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/rampNumericBuckets.html
+++ b/example/styling/rampNumericBuckets.html
@@ -29,7 +29,6 @@
     <div id='map'></div>
 </body>
 <script>
-    mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
     const map = new mapboxgl.Map({
         container: 'map',
         style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/rampNumericLinear.html
+++ b/example/styling/rampNumericLinear.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/rgba.html
+++ b/example/styling/rgba.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',

--- a/example/styling/ships.html
+++ b/example/styling/ships.html
@@ -19,7 +19,6 @@
         <div id='map'></div>
     </body>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1IjoiZG1hbnphbmFyZXMiLCJhIjoiY2o5cHRhOGg5NWdzbTJxcXltb2g2dmE5NyJ9.RVto4DnlLzQc26j9H0g9_A';
         const map = new mapboxgl.Map({
             container: 'map',
             style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',


### PR DESCRIPTION
As we are not using any Mapbox APIs for the examples, we don't need to use an access token.