### PR TITLE
Hide attribution locally

### DIFF
--- a/example/basic/multi-layer.html
+++ b/example/basic/multi-layer.html
@@ -4,6 +4,7 @@
         <title>Multi layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/basic/single-layer.html
+++ b/example/basic/single-layer.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/hide-attribution.js
+++ b/example/hide-attribution.js
@@ -1,0 +1,6 @@
+// This script hides the map attribution when served locally improving screenshot testing precission.
+if (document.URL.includes('localhost')) {
+    const styleElement = document.createElement('style');
+    styleElement.innerText = `.mapboxgl-ctrl.mapboxgl-ctrl-attrib {  display: none; }`;
+    document.head.appendChild(styleElement);
+}

--- a/example/styling/cielab.html
+++ b/example/styling/cielab.html
@@ -5,6 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
         <!-- Include CARTO GL JS -->
+        <script src="../hide-attribution.js"></script>
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->
         <script src="../../vendor/mapbox-gl-dev.js"></script>

--- a/example/styling/default-all.html
+++ b/example/styling/default-all.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/float.html
+++ b/example/styling/float.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/floatMul.html
+++ b/example/styling/floatMul.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/hsv.html
+++ b/example/styling/hsv.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/now.html
+++ b/example/styling/now.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/opacity.html
+++ b/example/styling/opacity.html
@@ -5,6 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
         <!-- Include CARTO GL JS -->
+        <script src="../hide-attribution.js"></script>
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->
         <script src="../../vendor/mapbox-gl-dev.js"></script>

--- a/example/styling/ordering_asc.html
+++ b/example/styling/ordering_asc.html
@@ -5,6 +5,7 @@
     <title>Single layer | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <script src="../hide-attribution.js"></script>
     <!-- Include CARTO GL JS -->
     <script src="../../dist/carto-gl.js"></script>
     <!-- Include Mapbox GL JS -->

--- a/example/styling/ordering_desc.html
+++ b/example/styling/ordering_desc.html
@@ -5,6 +5,7 @@
     <title>Single layer | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <script src="../hide-attribution.js"></script>
     <!-- Include CARTO GL JS -->
     <script src="../../dist/carto-gl.js"></script>
     <!-- Include Mapbox GL JS -->

--- a/example/styling/ordering_source.html
+++ b/example/styling/ordering_source.html
@@ -5,6 +5,7 @@
     <title>Single layer | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <script src="../hide-attribution.js"></script>
     <!-- Include CARTO GL JS -->
     <script src="../../dist/carto-gl.js"></script>
     <!-- Include Mapbox GL JS -->

--- a/example/styling/quantiles.html
+++ b/example/styling/quantiles.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/rampCategoryAuto.html
+++ b/example/styling/rampCategoryAuto.html
@@ -5,6 +5,7 @@
     <title>Single layer | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <script src="../hide-attribution.js"></script>
     <!-- Include CARTO GL JS -->
     <script src="../../dist/carto-gl.js"></script>
     <!-- Include Mapbox GL JS -->

--- a/example/styling/rampCategoryBuckets.html
+++ b/example/styling/rampCategoryBuckets.html
@@ -5,6 +5,7 @@
     <title>Single layer | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <script src="../hide-attribution.js"></script>
     <!-- Include CARTO GL JS -->
     <script src="../../dist/carto-gl.js"></script>
     <!-- Include Mapbox GL JS -->

--- a/example/styling/rampCategoryTop.html
+++ b/example/styling/rampCategoryTop.html
@@ -5,6 +5,7 @@
     <title>Single layer | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <script src="../hide-attribution.js"></script>
     <!-- Include CARTO GL JS -->
     <script src="../../dist/carto-gl.js"></script>
     <!-- Include Mapbox GL JS -->

--- a/example/styling/rampNumericAuto.html
+++ b/example/styling/rampNumericAuto.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/rampNumericBuckets.html
+++ b/example/styling/rampNumericBuckets.html
@@ -5,6 +5,7 @@
     <title>Single layer | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <script src="../hide-attribution.js"></script>
     <!-- Include CARTO GL JS -->
     <script src="../../dist/carto-gl.js"></script>
     <!-- Include Mapbox GL JS -->

--- a/example/styling/rampNumericLinear.html
+++ b/example/styling/rampNumericLinear.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/rgba.html
+++ b/example/styling/rgba.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/ships.html
+++ b/example/styling/ships.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->

--- a/example/styling/viewportMedian.html
+++ b/example/styling/viewportMedian.html
@@ -4,6 +4,7 @@
         <title>Single layer | CARTO</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
+        <script src="../hide-attribution.js"></script>
         <!-- Include CARTO GL JS -->
         <script src="../../dist/carto-gl.js"></script>
         <!-- Include Mapbox GL JS -->


### PR DESCRIPTION
Hide the map attribution when served locally (url contains localhost), this is usefull in screenshot testing since fonts are rendered with quite big differences depending on the OS/browser.

This is a diff between OSX/Linux see Red pixels pointing differences in the attribution div.

![diff](https://user-images.githubusercontent.com/2657897/36303943-2ea3c396-130e-11e8-9259-50466e64a940.png)
