### PR TITLE
Fix addTo(map) to work after map already loaded

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -99,13 +99,14 @@ const auth = {
 const source = new carto.source.Dataset('ne_10m_populated_places_simple', auth);
 const style = new carto.Style();
 const layer = new carto.Layer('myCartoLayer', source, style);
-layer.addTo(map, 'watername_ocean');
 
 setInterval(()=>{
     document.getElementById('title').innerText = `Demo dataset  ~ ${layer.getNumFeatures()} features`;
 }, 500)
 
 map.on('load', () => {
+    layer.addTo(map, 'watername_ocean');
+
     let index = 0;//styles.length - 1;
 
     function updateStyle(v) {

--- a/src/api/layer.js
+++ b/src/api/layer.js
@@ -118,7 +118,7 @@ export default class Layer {
     }
 
     _addToMGLMap(map, beforeLayerID) {
-        map.on('load', () => {
+        const onMapLoaded = () => {
             this._mglIntegrator = getMGLIntegrator(map);
             this._mglIntegrator.addLayer(this._id, beforeLayerID, this._getData.bind(this), () => {
                 this._dataframes.map(
@@ -132,7 +132,13 @@ export default class Layer {
                         dataframe.visible = false;
                     });
             });
-        });
+        };
+
+        if (map.loaded()) {
+            onMapLoaded();
+        } else {
+            map.on('load', onMapLoaded);
+        }
     }
 
     _styleChanged() {

--- a/src/api/layer.js
+++ b/src/api/layer.js
@@ -150,19 +150,19 @@ export default class Layer {
             throw new CartoValidationError('layer', 'nonValidMap');
         }
     }
-    
+
     hasDataframes() {
         return this._dataframes.length > 0;
     }
-    
+
     getId() {
         return this._id;
     }
-    
+
     getSource() {
         return this._source;
     }
-    
+
     getStyle() {
         return this._style;
     }
@@ -182,16 +182,18 @@ export default class Layer {
     }
 
     _addToMGLMap(map, beforeLayerID) {
-        const onMapLoaded = () => {
-            this._integrator = getMGLIntegrator(map);
-            this._integrator.addLayer(this, beforeLayerID);
-        };
-
         if (map.loaded()) {
-            onMapLoaded();
+            this._onMapLoaded(map, beforeLayerID);
         } else {
-            map.on('load', onMapLoaded);
+            map.on('load', () => {
+                this._onMapLoaded(map, beforeLayerID);
+            });
         }
+    }
+
+    _onMapLoaded(map, beforeLayerID) {
+        this._integrator = getMGLIntegrator(map);
+        this._integrator.addLayer(this, beforeLayerID);
     }
 
     _styleChanged() {

--- a/test/unit/api/layer.test.js
+++ b/test/unit/api/layer.test.js
@@ -6,7 +6,7 @@ describe('api/layer', () => {
     let source;
     let style, style2;
 
-    beforeEach(function () {
+    beforeEach(() => {
         source = new Dataset('ne_10m_populated_places_simple', {
             user: 'test',
             apiKey: '1234567890'
@@ -23,32 +23,32 @@ describe('api/layer', () => {
             expect(layer.getStyle()).toEqual(style);
         });
 
-        it('should throw an error if id is not valid', function () {
-            expect(function () {
+        it('should throw an error if id is not valid', () => {
+            expect(() => {
                 new Layer();
             }).toThrowError('`id` property required.');
-            expect(function () {
+            expect(() => {
                 new Layer({});
             }).toThrowError('`id` property must be a string.');
-            expect(function () {
+            expect(() => {
                 new Layer('');
             }).toThrowError('`id` property must be not empty.');
         });
 
-        it('should throw an error if source is not valid', function () {
-            expect(function () {
+        it('should throw an error if source is not valid', () => {
+            expect(() => {
                 new Layer('layer0');
             }).toThrowError('`source` property required.');
-            expect(function () {
+            expect(() => {
                 new Layer('layer0', {});
             }).toThrowError('The given object is not a valid source. See "carto.source.Base".');
         });
 
-        it('should throw an error if style is not valid', function () {
-            expect(function () {
+        it('should throw an error if style is not valid', () => {
+            expect(() => {
                 new Layer('layer0', source);
             }).toThrowError('`style` property required.');
-            expect(function () {
+            expect(() => {
                 new Layer('layer0', source, {});
             }).toThrowError('The given object is not a valid style. See "carto.Style".');
         });
@@ -69,7 +69,7 @@ describe('api/layer', () => {
                 layer.blendToStyle(style2);
             }).not.toThrow();
         });
-        it('should throw an error if style is not valid', function () {
+        it('should throw an error if style is not valid', () => {
             const layer = new Layer('layer0', source, style);
             expect(function () {
                 layer.blendToStyle();
@@ -81,6 +81,50 @@ describe('api/layer', () => {
     });
 
     describe('.addTo', () => {
+        describe('._addToMGLMap', () => {
+            beforeEach(() => {
+                this.layer = new Layer('layer0', source, style);
+                this.layer._onMapLoaded = () => {};
+                spyOn(this.layer, '_onMapLoaded');
+            });
 
+            it('should call onMapLoaded when the map is loaded', () => {
+                const mapMock = { loaded: () => true };
+                this.layer._addToMGLMap(mapMock);
+                expect(this.layer._onMapLoaded).toHaveBeenCalledWith(mapMock, undefined);
+            });
+
+            it('should not call onMapLoaded when the map is not loaded', () => {
+                const mapMock = { loaded: () => false, on: () => {} };
+                this.layer._addToMGLMap(mapMock);
+                expect(this.layer._onMapLoaded).not.toHaveBeenCalled();
+            });
+
+            it('should call onMapLoaded when the map `load` event is triggered', () => {
+                const mapMock = {
+                    loaded: () => false,
+                    on: (id, callback) => {
+                        if (id === 'load') {
+                            callback();
+                        }
+                    }
+                };
+                this.layer._addToMGLMap(mapMock);
+                expect(this.layer._onMapLoaded).toHaveBeenCalledWith(mapMock, undefined);
+            });
+
+            it('should not call onMapLoaded when other the map event is triggered', () => {
+                const mapMock = {
+                    loaded: () => false,
+                    on: (id, callback) => {
+                        if (id === 'other') {
+                            callback();
+                        }
+                    }
+                };
+                this.layer._addToMGLMap(mapMock);
+                expect(this.layer._onMapLoaded).not.toHaveBeenCalled();
+            });
+        });
     });
 });


### PR DESCRIPTION
I found this problem. When the map is already loaded, the `layer.addTo(map)` doesn't have any effect.

This is just a proposal. I would love @IagoLast and @Jesus89 could take some time to think about this because I'm pretty sure we could have this problem with other API methods, e.g. `remove()`.