### PR TITLE
FSAA

### DIFF
--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -87,14 +87,6 @@ Renderer.prototype._initGL = function (gl) {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 
     this._AATex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, this._AATex);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA,
-        800, 800, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-
     this._AAFB = gl.createFramebuffer();
     gl.bindFramebuffer(gl.FRAMEBUFFER, this._AAFB);
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this._AATex, 0);
@@ -594,8 +586,6 @@ Renderer.prototype.refresh = function (timestamp) {
         const [w, h] = [gl.drawingBufferWidth, gl.drawingBufferHeight];
 
         if (w != this._width || h != this._height) {
-            console.log(w,h);
-            this._AATex = gl.createTexture();
             gl.bindTexture(gl.TEXTURE_2D, this._AATex);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA,
                 w*2, h*2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
@@ -606,12 +596,10 @@ Renderer.prototype.refresh = function (timestamp) {
             gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this._AATex, 0);
 
             [this._width, this._height] = [w, h];
-
         }
         gl.viewport(0, 0, w*2, h*2);
         gl.clear(gl.COLOR_BUFFER_BIT);
     }
-
 
     const s = 1. / this._zoom;
 
@@ -705,25 +693,15 @@ Renderer.prototype.refresh = function (timestamp) {
         renderDrawPass(orderingIndex);
     });
 
-
-    //TODO if not points =>
-    /*
-        bind fb 0
-        use fsBlend program
-        bind aaFBtex to texture unit
-        render full screen
-    */
     if (tiles.length && tiles[0].type != 'point') {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
         gl.useProgram(this._aaBlendShader.program);
 
-
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, this._AATex);
         gl.uniform1i(this._aaBlendShader.readTU, 0);
-
 
         gl.enableVertexAttribArray(this._aaBlendShader.vertexAttribute);
         gl.bindBuffer(gl.ARRAY_BUFFER, this.bigTriangleVBO);

--- a/src/core/shaders/aaBlender.js
+++ b/src/core/shaders/aaBlender.js
@@ -1,0 +1,28 @@
+//TODO Discuss size scaling constant, maybe we need to remap using an exponential map
+
+export const VS = `
+
+precision highp float;
+attribute vec2 vertex;
+
+varying  vec2 uv;
+
+void main(void) {
+    uv = vertex*0.5+vec2(0.5);
+    gl_Position = vec4(vertex, 0.5, 1.);
+}
+`;
+
+export const FS = `
+
+precision highp float;
+
+varying  vec2 uv;
+
+uniform sampler2D aaTex;
+
+void main(void) {
+    vec4 aa = texture2D(aaTex, uv);
+    gl_FragColor = aa;//vec4(0,1,0,1);
+}
+`;

--- a/src/core/shaders/aaBlender.js
+++ b/src/core/shaders/aaBlender.js
@@ -1,4 +1,3 @@
-//TODO Discuss size scaling constant, maybe we need to remap using an exponential map
 
 export const VS = `
 
@@ -23,6 +22,6 @@ uniform sampler2D aaTex;
 
 void main(void) {
     vec4 aa = texture2D(aaTex, uv);
-    gl_FragColor = aa;//vec4(0,1,0,1);
+    gl_FragColor = aa;
 }
 `;

--- a/src/core/shaders/index.js
+++ b/src/core/shaders/index.js
@@ -1,5 +1,6 @@
 import * as rendererGLSL from './renderer';
 import * as stylerGLSL from './styler';
+import * as aaBlenderGLSL from './aaBlender';
 
 const NUM_TEXTURE_LOCATIONS = 4;
 
@@ -26,6 +27,14 @@ function compileProgram(gl, glslVS, glslFS) {
     gl.deleteShader(FS);
     if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
         throw new Error('Unable to link the shader program: ' + gl.getProgramInfoLog(this.program));
+    }
+}
+
+class AABlender {
+    constructor(gl) {
+        compileProgram.call(this, gl, aaBlenderGLSL.VS, aaBlenderGLSL.FS);
+        this.vertexAttribute = gl.getAttribLocation(this.program, 'vertex');
+        this.readTU = gl.getUniformLocation(this.program, 'aaTex');
     }
 }
 
@@ -106,4 +115,4 @@ const styler = {
     }
 };
 
-export { renderer, styler };
+export { renderer, styler, AABlender };


### PR DESCRIPTION
This PR adds Full Screen Anti Aliasing (FSAA) to lines and polygons rendering (to anything that is not points, actually).

MSAA is faster, but it is quite limited in WebGL 1, and it is problematic to use while integrating this library with MGL.

Points do not need this since their shader already includes a distance field based AA.

Fixes https://github.com/CartoDB/renderer-prototype/issues/36
Partially fixes https://github.com/CartoDB/renderer-prototype/issues/68