### PR TITLE
Remove legacy computejobs

### DIFF
--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -48,7 +48,6 @@ class Renderer {
         this._zoom = 1;
         console.log('R', this);
         this.dataframes = [];
-        this.computePool = []; //TODO hack, refactor needed
     }
 
     _initGL(gl) {
@@ -557,10 +556,6 @@ class Renderer {
             gl.disableVertexAttribArray(this._aaBlendShader.vertexAttribute);
         }
 
-
-        this.computePool.map(job => job.work(this));
-        this.computePool = [];
-
         gl.disable(gl.CULL_FACE);
     }
 
@@ -574,15 +569,6 @@ class Renderer {
         this.lineRendererProgram = shaders.renderer.createLineShader(this.gl);
         this._aaBlendShader = new shaders.AABlender(this.gl);
     }
-
-    compute(type, expressions) {
-        // TODO remove this
-        const promise = new Promise((resolve) => {
-            this.computePool.push(new ComputeJob(type, expressions, resolve));
-        });
-        return promise;
-    }
-
 }
 
 
@@ -711,21 +697,6 @@ function decodeGeom(geomType, geom) {
         };
     } else {
         throw new Error(`Unimplemented geometry type: '${geomType}'`);
-    }
-}
-
-
-
-class ComputeJob {
-    constructor(type, expressions, resolve) {
-        this.resolve = resolve;
-    }
-    work(renderer) {
-        let sum = 0;
-        renderer.dataframes.filter(t => t.style).map(t => {
-            sum += t.numFeatures;
-        });
-        this.resolve(sum);
     }
 }
 


### PR DESCRIPTION
The computejobs legacy code was initially intended to compute metadata and get the number of features, both things have been implemented in other ways and this legacy code should be removed.