### PR TITLE
Fix "AND" expression

### DIFF
--- a/src/core/style/expressions/binary.js
+++ b/src/core/style/expressions/binary.js
@@ -19,8 +19,8 @@ export const LessThanOrEqualTo = genBinaryOp((x, y) => x <= y ? 1 : 0, (x, y) =>
 export const Equals = genBinaryOp((x, y) => x == y ? 1 : 0, (x, y) => `(${x}==${y}? 1.:0.)`);
 export const NotEquals = genBinaryOp((x, y) => x != y ? 1 : 0, (x, y) => `(${x}!=${y}? 1.:0.)`);
 
-export const Or = genBinaryOp((x, y) => Math.min(x + y, 1), (x, y) => `min(${x} + ${y}, 1.)`);
-export const And = genBinaryOp((x, y) => x * y, (x, y) => `(${x} * ${y})`);
+export const  Or = genBinaryOp((x, y) => Math.min(x + y, 1), (x, y) => `min(${x} + ${y}, 1.)`);
+export const And = genBinaryOp((x, y) => Math.min(x * y, 1), (x, y) => `min(${x} * ${y}, 1.)`);
 
 function genBinaryOp(jsFn, glsl) {
     return class BinaryOperation extends Expression {


### PR DESCRIPTION
Results where different when evaluating `and(true, 10)`and  `and(1, 10)`

This commit fixes this ensuring a range [0,1]