### PR TITLE
Fix multilayer

### DIFF
--- a/src/api/integrator/mapbox-gl.js
+++ b/src/api/integrator/mapbox-gl.js
@@ -47,7 +47,7 @@ class MGLIntegrator {
                 this.invalidateWebGLState = invalidate;
                 this.notifyObservers();
                 this.renderer._initGL(gl);
-                layer.initCallback();
+                this._layers.map(layer => layer.initCallback());
             }
             layer.paintCallback();
             invalidate();
@@ -56,7 +56,7 @@ class MGLIntegrator {
             id: layerId,
             type: 'custom-webgl'
         }, beforeLayerID);
-        this._layers.push(layerId);
+        this._layers.push(layer);
         this.move();
     }
     needRefresh() {

--- a/src/api/layer.js
+++ b/src/api/layer.js
@@ -335,7 +335,7 @@ export default class Layer {
 
     async requestData(style) {
         style = style || this._style;
-        if (!style){
+        if (!style) {
             return;
         }
         await this._context;

--- a/src/api/style.js
+++ b/src/api/style.js
@@ -8,13 +8,13 @@ import Expression from '../core/style/expressions/expression';
 import CartoValidationError from './error-handling/carto-validation-error';
 
 
-const DEFAULT_RESOLUTION = 1;
-const DEFAULT_COLOR_EXPRESSION = s.rgba(0, 1, 0, 0.5);
-const DEFAULT_WIDTH_EXPRESSION = s.float(5);
-const DEFAULT_STROKE_COLOR_EXPRESSION = s.rgba(0, 1, 0, 0.5);
-const DEFAULT_STROKE_WIDTH_EXPRESSION = s.float(0);
-const DEFAULT_ORDER_EXPRESSION = s.noOrder();
-const DEFAULT_FILTER_EXPRESSION = s.floatConstant(1);
+const DEFAULT_RESOLUTION = () => 1;
+const DEFAULT_COLOR_EXPRESSION = () => s.rgba(0, 1, 0, 0.5);
+const DEFAULT_WIDTH_EXPRESSION = () => s.float(5);
+const DEFAULT_STROKE_COLOR_EXPRESSION = () => s.rgba(0, 1, 0, 0.5);
+const DEFAULT_STROKE_WIDTH_EXPRESSION = () => s.float(0);
+const DEFAULT_ORDER_EXPRESSION = () => s.noOrder();
+const DEFAULT_FILTER_EXPRESSION = () => s.floatConstant(1);
 const SUPPORTED_PROPERTIES = [
     'resolution',
     'color',
@@ -281,13 +281,13 @@ export default class Style {
      * @return {StyleSpec}
      */
     _setDefaults(styleSpec) {
-        styleSpec.resolution = util.isUndefined(styleSpec.resolution) ? DEFAULT_RESOLUTION : styleSpec.resolution;
-        styleSpec.color = styleSpec.color || DEFAULT_COLOR_EXPRESSION;
-        styleSpec.width = styleSpec.width || DEFAULT_WIDTH_EXPRESSION;
-        styleSpec.strokeColor = styleSpec.strokeColor || DEFAULT_STROKE_COLOR_EXPRESSION;
-        styleSpec.strokeWidth = styleSpec.strokeWidth || DEFAULT_STROKE_WIDTH_EXPRESSION;
-        styleSpec.order = styleSpec.order || DEFAULT_ORDER_EXPRESSION;
-        styleSpec.filter = styleSpec.filter || DEFAULT_FILTER_EXPRESSION;
+        styleSpec.resolution = util.isUndefined(styleSpec.resolution) ? DEFAULT_RESOLUTION() : styleSpec.resolution;
+        styleSpec.color = styleSpec.color || DEFAULT_COLOR_EXPRESSION();
+        styleSpec.width = styleSpec.width || DEFAULT_WIDTH_EXPRESSION();
+        styleSpec.strokeColor = styleSpec.strokeColor || DEFAULT_STROKE_COLOR_EXPRESSION();
+        styleSpec.strokeWidth = styleSpec.strokeWidth || DEFAULT_STROKE_WIDTH_EXPRESSION();
+        styleSpec.order = styleSpec.order || DEFAULT_ORDER_EXPRESSION();
+        styleSpec.filter = styleSpec.filter || DEFAULT_FILTER_EXPRESSION();
         return styleSpec;
     }
 

--- a/src/core/shaders/index.js
+++ b/src/core/shaders/index.js
@@ -6,6 +6,8 @@ import ShaderCache from './shader-cache';
 const NUM_TEXTURE_LOCATIONS = 4;
 const shaderCache = new ShaderCache();
 
+let programID = 1;
+
 function compileShader(gl, sourceCode, type) {
     if (shaderCache.has(gl, sourceCode)) {
         return shaderCache.get(gl, sourceCode);
@@ -34,6 +36,7 @@ function compileProgram(gl, glslVS, glslFS) {
     if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
         throw new Error('Unable to link the shader program: ' + gl.getProgramInfoLog(this.program));
     }
+    this.programID = programID++;
 }
 
 class AABlender {


### PR DESCRIPTION
Fix for https://github.com/CartoDB/renderer-prototype/issues/146

The main problem was that in `mapbox-gl.js` only one layer initCallback was being called.

However, there was another problem, expressions with multiple parents are not supported, but `style.js` was sharing expressions between styles, this caused some WebGL warnings and it was going to explode sooner or later, so I fixed it.