### PR TITLE
Suggestions for map examples

### DIFF
--- a/examples/expressions/filter.html
+++ b/examples/expressions/filter.html
@@ -44,7 +44,7 @@
     const avg = s.viewportAvg(s.prop('dn'));
     const style = new carto.Style({
         color: s.ramp(s.buckets(s.prop('dn'), avg), s.palettes.prism),
-        filter: s.between(s.property('dn'), 60, 70)
+        filter: s.between(s.prop('dn'), 60, 70)
 
     });
     const layer = new carto.Layer('layer', source, style);

--- a/examples/expressions/order.html
+++ b/examples/expressions/order.html
@@ -86,13 +86,10 @@
     `);
     const s = carto.style.expressions;
     const style = new carto.Style({
-        width: s.mul(
-            s.mul(s.sqrt(s.div(s.prop('amount'), 5000)), 20),
-            s.mul(s.add(s.div(s.zoom(), 4000), 0.01), 1.5)
-        ),
+        width: s.sqrt('amount'),
         color: s.ramp(s.prop('category'), s.palettes.prism),
-        strokeColor: s.rgba(0, 0, 0, 0.7),
-        strokeWidth: s.div(s.zoom(), 10000),
+        strokeColor: s.rgba(1, 1, 1, 0.7),
+        strokeWidth: 1,
     });
     const layer = new carto.Layer('layer', source, style);
 
@@ -100,38 +97,29 @@
 
     function setDefaultOrder() {
       layer.blendToStyle(new carto.Style({
-          width: s.mul(
-              s.mul(s.sqrt(s.div(s.prop('amount'), 5000)), 20),
-              s.mul(s.add(s.div(s.zoom(), 4000), 0.01), 1.5)
-          ),
+          width: s.sqrt('amount'),
           color: s.ramp(s.prop('category'), s.palettes.prism),
-          strokeColor: s.rgba(0, 0, 0, 0.7),
-          strokeWidth: s.div(s.zoom(), 10000),
+          strokeColor: s.rgba(1, 1, 1, 0.7),
+          strokeWidth: 1,
       }));
     }
 
     function setAscOrder() {
       layer.blendToStyle(new carto.Style({
-          width: s.mul(
-              s.mul(s.sqrt(s.div(s.prop('amount'), 5000)), 20),
-              s.mul(s.add(s.div(s.zoom(), 4000), 0.01), 1.5)
-          ),
+          width: s.sqrt('amount'),
           color: s.ramp(s.prop('category'), s.palettes.prism),
-          strokeColor: s.rgba(0, 0, 0, 0.7),
-          strokeWidth: s.div(s.zoom(), 10000),
+          strokeColor: s.rgba(1, 1, 1, 0.7),
+          strokeWidth: 1,
           order: s.asc(s.width())
       }));
     }
 
     function setDescOrder() {
       layer.blendToStyle(new carto.Style({
-          width: s.mul(
-              s.mul(s.sqrt(s.div(s.prop('amount'), 5000)), 20),
-              s.mul(s.add(s.div(s.zoom(), 4000), 0.01), 1.5)
-          ),
+          width: s.sqrt('amount'),
           color: s.ramp(s.prop('category'), s.palettes.prism),
-          strokeColor: s.rgba(0, 0, 0, 0.7),
-          strokeWidth: s.div(s.zoom(), 10000),
+          strokeColor: s.rgba(1, 1, 1, 0.7),
+          strokeWidth: 1,
           order: s.desc(s.width())
       }));
     }

--- a/examples/expressions/order.html
+++ b/examples/expressions/order.html
@@ -88,7 +88,7 @@
     const style = new carto.Style({
         width: s.sqrt('amount'),
         color: s.ramp(s.prop('category'), s.palettes.prism),
-        strokeColor: s.rgba(1, 1, 1, 0.7),
+        strokeColor: s.rgba(1, 1, 1, 0.5),
         strokeWidth: 1,
     });
     const layer = new carto.Layer('layer', source, style);
@@ -99,7 +99,7 @@
       layer.blendToStyle(new carto.Style({
           width: s.sqrt('amount'),
           color: s.ramp(s.prop('category'), s.palettes.prism),
-          strokeColor: s.rgba(1, 1, 1, 0.7),
+          strokeColor: s.rgba(1, 1, 1, 0.5),
           strokeWidth: 1,
       }));
     }
@@ -108,7 +108,7 @@
       layer.blendToStyle(new carto.Style({
           width: s.sqrt('amount'),
           color: s.ramp(s.prop('category'), s.palettes.prism),
-          strokeColor: s.rgba(1, 1, 1, 0.7),
+          strokeColor: s.rgba(1, 1, 1, 0.5),
           strokeWidth: 1,
           order: s.asc(s.width())
       }));
@@ -118,7 +118,7 @@
       layer.blendToStyle(new carto.Style({
           width: s.sqrt('amount'),
           color: s.ramp(s.prop('category'), s.palettes.prism),
-          strokeColor: s.rgba(1, 1, 1, 0.7),
+          strokeColor: s.rgba(1, 1, 1, 0.5),
           strokeWidth: 1,
           order: s.desc(s.width())
       }));

--- a/examples/expressions/ramp-category.html
+++ b/examples/expressions/ramp-category.html
@@ -66,10 +66,6 @@
         <input type="radio" name="style" onclick="setRampTop()" id="top">
         <label for="top">Ramp top</label>
       </li>
-      <li>
-        <input type="radio" name="style" onclick="setRampQuantiles()" id="quantiles">
-        <label for="quantiles">Ramp quantiles</label>
-      </li>
     </ul>
   </div>
   <script>
@@ -90,7 +86,7 @@
     `);
     const s = carto.style.expressions;
     const style = new carto.Style({
-      color: s.ramp(s.property('category'), s.palettes.prism)
+      color: s.ramp(s.property('category'), s.palettes.vivid)
     });
     const layer = new carto.Layer('layer', source, style);
 
@@ -98,25 +94,19 @@
 
     function setRampAuto() {
       layer.blendToStyle(new carto.Style({
-        color: s.ramp(s.prop('category'), s.palettes.prism)
+        color: s.ramp(s.prop('category'), s.palettes.vivid)
       }));
     }
 
     function setRampBuckets() {
       layer.blendToStyle(new carto.Style({
-          color: s.ramp(s.buckets(s.prop('category'), 'Salud'), s.palettes.prism)
+          color: s.ramp(s.buckets(s.prop('category'), 'Moda y calzado'), s.palettes.vivid)
       }));
     }
 
     function setRampTop() {
       layer.blendToStyle(new carto.Style({
-        color: s.ramp(s.top(s.prop('category'), 3), s.palettes.prism)
-      }));
-    }
-    
-    function setRampQuantiles() {
-      layer.blendToStyle(new carto.Style({
-        color: s.ramp(s.quantiles(s.prop('daytime'), 3), s.palettes.earth)
+        color: s.ramp(s.top(s.prop('category'), 3), s.palettes.vivid)
       }));
     }
   </script>

--- a/examples/expressions/ramp-category.html
+++ b/examples/expressions/ramp-category.html
@@ -86,7 +86,7 @@
     `);
     const s = carto.style.expressions;
     const style = new carto.Style({
-      color: s.ramp(s.property('category'), s.palettes.vivid)
+      color: s.ramp(s.prop('category'), s.palettes.vivid)
     });
     const layer = new carto.Layer('layer', source, style);
 

--- a/examples/expressions/ramp-numeric.html
+++ b/examples/expressions/ramp-numeric.html
@@ -55,7 +55,7 @@
   <div id="controls">
     <ul>
       <li>
-        <input type="radio" name="style" onclick="setRampAuto()" id="auto" checked>
+        <input type="radio" name="style" onclick="setRampQuantiles()" id="auto" checked>
         <label for="auto">Ramp quantiles</label>
       </li>
       <li>
@@ -86,7 +86,7 @@
     `);
     const s = carto.style.expressions;
     const style = new carto.Style({
-      color: s.ramp(s.prop('numfloors'), s.palettes.sunset)
+      color: s.ramp(s.quantiles(s.prop('numfloors'), 5), s.palettes.sunset)
     });
     const layer = new carto.Layer('layer', source, style);
 

--- a/examples/expressions/ramp-numeric.html
+++ b/examples/expressions/ramp-numeric.html
@@ -56,7 +56,7 @@
     <ul>
       <li>
         <input type="radio" name="style" onclick="setRampAuto()" id="auto" checked>
-        <label for="auto">Ramp auto</label>
+        <label for="auto">Ramp quantiles</label>
       </li>
       <li>
         <input type="radio" name="style" onclick="setRampBuckets()" id="buckets">
@@ -86,27 +86,27 @@
     `);
     const s = carto.style.expressions;
     const style = new carto.Style({
-      color: s.ramp(s.prop('numfloors'), s.palettes.earth)
+      color: s.ramp(s.prop('numfloors'), s.palettes.sunset)
     });
     const layer = new carto.Layer('layer', source, style);
 
     layer.addTo(map, 'watername_ocean');
 
-    function setRampAuto() {
+    function setRampQuantiles() {
       layer.blendToStyle(new carto.Style({
-        color: s.ramp(s.prop('numfloors'), s.palettes.earth)
+        color: s.ramp(s.quantiles(s.prop('numfloors'), 5), s.palettes.sunset)
       }));
     }
 
     function setRampBuckets() {
       layer.blendToStyle(new carto.Style({
-        color: s.ramp(s.buckets(s.prop('numfloors'), 1, 4, 7, 15), s.palettes.prism)
+        color: s.ramp(s.buckets(s.prop('numfloors'), 1, 4, 7, 15), s.palettes.sunset)
       }));
     }
 
     function setRampLinear() {
       layer.blendToStyle(new carto.Style({
-        color: s.ramp(s.linear(s.prop('numfloors'), 1, 40), s.palettes.earth)
+        color: s.ramp(s.linear(s.prop('numfloors'), 1, 40), s.palettes.sunset)
       }));
     }
   </script>

--- a/examples/expressions/viewport.html
+++ b/examples/expressions/viewport.html
@@ -41,9 +41,9 @@
       pop_density_points
     `);
     const s = carto.style.expressions;
-    const median = s.viewportPercentile(s.property('dn'), 50);
+    const median = s.viewportPercentile(s.prop('dn'), 50);
     const style = new carto.Style({
-        color: s.ramp(s.quantiles(s.property('dn'), 4), s.palettes.earth),
+        color: s.ramp(s.quantiles(s.prop('dn'), 4), s.palettes.earth),
         width: s.sub(median, 90)
     });
     const layer = new carto.Layer('layer', source, style);


### PR DESCRIPTION
@Jesus89 

This is a PR for some adjustments to your example maps.

Description by file below. Some of them I couldn't figure out exactly how to modify given the example you were showing so you will find notes about those below too.

**`ramp-category.html`**:
+ I changed the color scheme to `vivid` for better contrast to demonstrate the different options
+ For the category `buckets` I changed the category to `Moda y clazado` because that is the most common category attribute and easier to see vs. `Salud`
+ I removed the `quantiles` example because we shouldn't use a classification method for categorical data

**`ramp-numeric.html`**
+ I removed `ramp auto` because it doesn't really do anything and probably not something that we want to encourage people to do
+ I added `ramp quantiles` to this example because it is appropriate for the numeric attribute
  + **note**: it isn't working I'm not sure why is it the attribute, a bug,... ?
+ I changed the color scheme to `sunset` so visually, you can see the differences better

**`order.html`**
*hopefully I got the syntax right :)*
+ I adjusted the marker `strokeColor` so it isn't so overpowering
+ I modified the `width` styling to be less complex (if the purpose was to show complexity, change back, but I figured it was to show ordering of symbol sizes more than complex styling expressions)
+ Similarly, I simplified the `strokeWidth`

There are other modifications that we should make that I wasn't able to: 

**`filter.html`**: 
+ we shouldn't display the color with `prism` it should be a sequential color scheme. [I tried to recreate that map](https://cartodb.github.io/renderer-prototype/example/mapbox.html#eyJhIjoicG9wX2RlbnNpdHlfcG9pbnRzIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IndpZHRoOiB6b29tKClcbmNvbG9yOiByYW1wKGJ1Y2tldHModmlld3BvcnRBVkcoJGRuKSksIHByaXNtKVxuZmlsdGVyOiBiZXR3ZWVuKCgkZG4pLDYwLDcwKVxuXG5cblxuIiwiZiI6eyJsbmciOi0xMTkuNjQwNDM1Mjg2NjIwNDYsImxhdCI6Ny4wMTM2ODE5NjYxNTA5NTV9LCJnIjowfQ==) with the editor, but didn't have luck so I couldn't adjust the styling you have.

**`viewport.html`**:
+ I would try a sequential color scheme vs. the diverging `earth`. diverging schemes are best to show above and below an average or standard deviation above or below... with quantiles, 4 classes, I'm not sure that you will see the classes that you should.
+ I'm not exactly sure what you are doing with the point `width` but the result is looking inconsistent through zoom


