### PR TITLE
Use exquisite-2.0-preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^4.15.0",
-    "exquisite-sst": "IagoLast/Exquisite#return-diff-pixels",
+    "exquisite-sst": "IagoLast/Exquisite#master",
     "glob": "^7.1.2",
     "http-server": "^0.11.1",
     "jasmine-core": "^2.99.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^4.15.0",
-    "exquisite-sst": "IagoLast/Exquisite#master",
+    "exquisite-sst": "IagoLast/Exquisite#return-diff-pixels",
     "glob": "^7.1.2",
     "http-server": "^0.11.1",
     "jasmine-core": "^2.99.1",

--- a/test/acceptance/e2e.test.js
+++ b/test/acceptance/e2e.test.js
@@ -14,6 +14,6 @@ describe('E2E tests:', () => {
 function test(file) {
     it(util.getName(file), () => {
         const actual = util.testSST(file, template, true);
-        return chai.expect(actual).to.eventually.be.true;
+        return chai.expect(actual).to.eventually.eq(0);
     }).timeout(20000);
 }

--- a/test/common/util.js
+++ b/test/common/util.js
@@ -56,7 +56,7 @@ function testSST(file, template, asyncLoad) {
     options.url = `file://${getHTML(file)}`;
     options.input = `${getPNG(file)}`;
     options.output = `${getOutPNG(file)}`;
-    options.consoleFn = msg => console.log(msg.text());
+    options.consoleFn = handleBrowserConsole;
     if (asyncLoad) options.waitForFn = () => window.loaded;
     return exquisite.test(options);
 }
@@ -102,6 +102,21 @@ function loadOptions() {
         viewportHeight: 300,
         headless: process.platform === 'linux'
     };
+}
+
+/**
+ * Handle puppeteer output.
+ * https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-consolemessage
+ * @param {ConsoleMessage} consoleMessage
+ */
+function handleBrowserConsole(consoleMessage) {
+    if (process.env.VERBOSE_LOG) {
+        console.log(consoleMessage.text());
+    } else {
+        if (consoleMessage.type() === 'warning' || consoleMessage.type() === 'error') {
+            console.log(consoleMessage.text());
+        }
+    }
 }
 
 module.exports = {

--- a/test/common/util.js
+++ b/test/common/util.js
@@ -56,6 +56,7 @@ function testSST(file, template, asyncLoad) {
     options.url = `file://${getHTML(file)}`;
     options.input = `${getPNG(file)}`;
     options.output = `${getOutPNG(file)}`;
+    options.consoleFn = msg => console.log(msg.text());
     if (asyncLoad) options.waitForFn = () => window.loaded;
     return exquisite.test(options);
 }
@@ -75,7 +76,7 @@ function loadGeoJSONSources() {
     const sourcesDir = path.resolve(__dirname, 'sources');
     const geojsonFiles = glob.sync(path.join(sourcesDir, '*.geojson'));
     let sources = {};
-    geojsonFiles.forEach(function(geojsonFile) {
+    geojsonFiles.forEach(function (geojsonFile) {
         const fileName = path.basename(geojsonFile, '.geojson');
         sources[fileName] = JSON.parse(fs.readFileSync(geojsonFile));
     });

--- a/test/integration/render.test.js
+++ b/test/integration/render.test.js
@@ -14,6 +14,6 @@ describe('Render tests:', () => {
 function test(file) {
     it(util.getName(file), () => {
         const actual = util.testSST(file, template);
-        return chai.expect(actual).to.eventually.eq(0);
+        return chai.expect(actual).to.eventually.be.at.most(1);
     }).timeout(10000);
 }

--- a/test/integration/render.test.js
+++ b/test/integration/render.test.js
@@ -14,6 +14,6 @@ describe('Render tests:', () => {
 function test(file) {
     it(util.getName(file), () => {
         const actual = util.testSST(file, template);
-        return chai.expect(actual).to.eventually.be.true;
+        return chai.expect(actual).to.eventually.eq(0);
     }).timeout(10000);
 }

--- a/test/integration/render.test.js
+++ b/test/integration/render.test.js
@@ -14,6 +14,7 @@ describe('Render tests:', () => {
 function test(file) {
     it(util.getName(file), () => {
         const actual = util.testSST(file, template);
+        // Temporary threshold (1px) to cover small renderer differences between Mac & Linux
         return chai.expect(actual).to.eventually.be.at.most(1);
     }).timeout(10000);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,8 +280,8 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
 ast-types@0.x.x:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.2.tgz#cc4e1d15a36b39979a1986fe1e91321cbfae7783"
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.3.tgz#c20757fe72ee71278ea0ff3d87e5c2ca30d9edf8"
 
 astw@^2.0.0:
   version "2.2.0"
@@ -687,7 +687,7 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
-cacache@^10.0.1:
+cacache@^10.0.4:
   version "10.0.4"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
   dependencies:
@@ -953,8 +953,8 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
 colors@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.1.tgz#f4a3d302976aaf042356ba1ade3b1a2c62d9d794"
 
 combine-lists@^1.0.0:
   version "1.0.1"
@@ -1439,8 +1439,8 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
     once "^1.4.0"
 
 engine.io-client@~3.1.0:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.1.5.tgz#85de17666560327ef1817978f6e3f8101ded2c47"
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.1.6.tgz#5bdeb130f8b94a50ac5cbeb72583e7a4a063ddfd"
   dependencies:
     component-emitter "1.2.1"
     component-inherit "0.0.3"
@@ -1503,8 +1503,8 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.39"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.39.tgz#fca21b67559277ca4ac1a1ed7048b107b6f76d87"
+  version "0.10.40"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.40.tgz#ab3d2179b943008c5e9ef241beb25ef41424c774"
   dependencies:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
@@ -1753,9 +1753,9 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-exquisite-sst@IagoLast/Exquisite#master:
+exquisite-sst@IagoLast/Exquisite#return-diff-pixels:
   version "1.2.0-next"
-  resolved "https://codeload.github.com/IagoLast/Exquisite/tar.gz/1f952bcb1973382eef4fcceda4f88b4ec4a6fde7"
+  resolved "https://codeload.github.com/IagoLast/Exquisite/tar.gz/97438b6cdf4707e46a6548f892b2caafe9721adb"
   dependencies:
     cloudinary "^1.9.0"
     minimist "^1.2.0"
@@ -2964,12 +2964,6 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
-lazy-cache@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
-  dependencies:
-    set-getter "^0.1.0"
-
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -4042,8 +4036,8 @@ raw-body@2, raw-body@2.3.2:
     unpipe "1.0.0"
 
 rc@^1.1.7:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.6.tgz#eb18989c6d4f4f162c399f79ddd29f3835568092"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -4215,8 +4209,8 @@ request@2.81.0:
     uuid "^3.0.0"
 
 request@^2.0.0, request@^2.74.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+  version "2.85.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -4361,7 +4355,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-schema-utils@^0.4.2:
+schema-utils@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
   dependencies:
@@ -4383,12 +4377,6 @@ serialize-javascript@^1.4.0:
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-
-set-getter@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
-  dependencies:
-    to-object-path "^0.3.0"
 
 set-immediate-shim@^1.0.1:
   version "1.0.1"
@@ -4504,8 +4492,8 @@ snapdragon-util@^3.0.1:
     kind-of "^3.2.0"
 
 snapdragon@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.1.tgz#e12b5487faded3e3dea0ac91e9400bf75b401370"
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
   dependencies:
     base "^0.11.1"
     debug "^2.2.0"
@@ -4514,7 +4502,7 @@ snapdragon@^0.8.1:
     map-cache "^0.2.2"
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
-    use "^2.0.0"
+    use "^3.1.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -4650,8 +4638,8 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -4664,8 +4652,8 @@ sshpk@^1.7.0:
     tweetnacl "~0.14.0"
 
 ssri@^5.2.4:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.2.4.tgz#9985e14041e65fc397af96542be35724ac11da52"
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
   dependencies:
     safe-buffer "^5.1.1"
 
@@ -5025,12 +5013,12 @@ uglifyjs-webpack-plugin@^0.4.6:
     webpack-sources "^1.0.1"
 
 uglifyjs-webpack-plugin@^1.1.8:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.2.tgz#e7516d4367afdb715c3847841eb46f94c45ca2b9"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.3.tgz#bf23197b37a8fc953fecfbcbab66e506f9a0ae72"
   dependencies:
-    cacache "^10.0.1"
+    cacache "^10.0.4"
     find-cache-dir "^1.0.0"
-    schema-utils "^0.4.2"
+    schema-utils "^0.4.5"
     serialize-javascript "^1.4.0"
     source-map "^0.6.1"
     uglify-es "^3.3.4"
@@ -5046,8 +5034,8 @@ ultron@~1.1.0:
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
 
 umd@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.1.tgz#8ae556e11011f63c2596708a8837259f01b3d60e"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.2.tgz#95bdbc6d3983050df600431f44e5faeb4b7b3d45"
 
 underscore-contrib@~0.3.0:
   version "0.3.0"
@@ -5124,13 +5112,11 @@ url@^0.11.0, url@~0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8"
+use@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
   dependencies:
-    define-property "^0.2.5"
-    isobject "^3.0.0"
-    lazy-cache "^2.0.2"
+    kind-of "^6.0.2"
 
 useragent@^2.1.12:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,9 +1753,9 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-exquisite-sst@IagoLast/Exquisite#return-diff-pixels:
+exquisite-sst@IagoLast/Exquisite#master:
   version "1.2.0-next"
-  resolved "https://codeload.github.com/IagoLast/Exquisite/tar.gz/97438b6cdf4707e46a6548f892b2caafe9721adb"
+  resolved "https://codeload.github.com/IagoLast/Exquisite/tar.gz/01084f38562eee3069641f43d9f91c2ae58ece6b"
   dependencies:
     cloudinary "^1.9.0"
     minimist "^1.2.0"


### PR DESCRIPTION
https://github.com/CartoDB/renderer-prototype/issues/151
---
This PR uses 2 new exquisite features:

- Exquisite now returns the number of different pixels instead a single boolean value.
  - Now every failing test tells the number of different pixels
  - We even can create manual thresholds "for this image allow up to 30 different pixels"
- Add a function to capture browser console
  - This way we can detect network errors, exceptions..etc.
  - By default only `warn` `error` is displayed.
  - verbose mode: `VERBOSE_LOG=true yarn test:render` 