### PR TITLE
new filter example

### DIFF
--- a/examples/expressions/filter.html
+++ b/examples/expressions/filter.html
@@ -41,11 +41,9 @@
       pop_density_points
     `);
     const s = carto.style.expressions;
-    const avg = s.viewportAvg(s.prop('dn'));
     const style = new carto.Style({
-        color: s.ramp(s.buckets(s.prop('dn'), avg), s.palettes.prism),
-        filter: s.between(s.prop('dn'), 60, 70)
-
+        color: s.ramp(s.quantiles(s.prop('dn'), 5), s.palettes.redor),
+        filter: s.between(s.prop('dn'), 100, 150)
     });
     const layer = new carto.Layer('layer', source, style);
 


### PR DESCRIPTION
@Jesus89 

adjusted the filter example. Basically, we are doing a quantiles classification on a filtered view between `100,150` so what you see on the map are high population density places.

