### PR TITLE
Allow numbers in width and strokeWidth properties

### DIFF
--- a/examples/expressions/order.html
+++ b/examples/expressions/order.html
@@ -86,7 +86,7 @@
     `);
     const s = carto.style.expressions;
     const style = new carto.Style({
-        width: s.sqrt('amount'),
+        width: s.sqrt(s.prop('amount')),
         color: s.ramp(s.prop('category'), s.palettes.prism),
         strokeColor: s.rgba(1, 1, 1, 0.5),
         strokeWidth: 1,
@@ -97,7 +97,7 @@
 
     function setDefaultOrder() {
       layer.blendToStyle(new carto.Style({
-          width: s.sqrt('amount'),
+          width: s.sqrt(s.prop('amount')),
           color: s.ramp(s.prop('category'), s.palettes.prism),
           strokeColor: s.rgba(1, 1, 1, 0.5),
           strokeWidth: 1,
@@ -106,7 +106,7 @@
 
     function setAscOrder() {
       layer.blendToStyle(new carto.Style({
-          width: s.sqrt('amount'),
+          width: s.sqrt(s.prop('amount')),
           color: s.ramp(s.prop('category'), s.palettes.prism),
           strokeColor: s.rgba(1, 1, 1, 0.5),
           strokeWidth: 1,
@@ -116,7 +116,7 @@
 
     function setDescOrder() {
       layer.blendToStyle(new carto.Style({
-          width: s.sqrt('amount'),
+          width: s.sqrt(s.prop('amount')),
           color: s.ramp(s.prop('category'), s.palettes.prism),
           strokeColor: s.rgba(1, 1, 1, 0.5),
           strokeWidth: 1,

--- a/src/api/style.js
+++ b/src/api/style.js
@@ -5,7 +5,7 @@ import * as shaders from '../core/shaders';
 import { compileShader } from '../core/style/shader-compiler';
 import { parseStyleDefinition } from '../core/style/parser';
 import Expression from '../core/style/expressions/expression';
-import Float from '../core/style/expressions/float';
+import { implicitCast } from '../core/style/expressions/utils';
 import CartoValidationError from './error-handling/carto-validation-error';
 
 
@@ -306,6 +306,9 @@ export default class Style {
 
         // TODO: Check expression types ie: color is not a number expression!
 
+        styleSpec.width = implicitCast(styleSpec.width);
+        styleSpec.strokeWidth = implicitCast(styleSpec.strokeWidth);
+
         if (!util.isNumber(styleSpec.resolution)) {
             throw new CartoValidationError('style', 'resolutionNumberRequired');
         }
@@ -315,14 +318,10 @@ export default class Style {
         if (!(styleSpec.strokeColor instanceof Expression)) {
             throw new CartoValidationError('style', 'nonValidExpression[strokeColor]');
         }
-        if (util.isNumber(styleSpec.width)) {
-            styleSpec.width = new Float(styleSpec.width);
-        } else if (!(styleSpec.width instanceof Expression)) {
+        if (!(styleSpec.width instanceof Expression)) {
             throw new CartoValidationError('style', 'nonValidExpression[width]');
         }
-        if (util.isNumber(styleSpec.strokeWidth)) {
-            styleSpec.strokeWidth = new Float(styleSpec.strokeWidth);
-        } else if (!(styleSpec.strokeWidth instanceof Expression)) {
+        if (!(styleSpec.strokeWidth instanceof Expression)) {
             throw new CartoValidationError('style', 'nonValidExpression[strokeWidth]');
         }
         if (!(styleSpec.order instanceof Expression)) {

--- a/src/api/style.js
+++ b/src/api/style.js
@@ -5,6 +5,7 @@ import * as shaders from '../core/shaders';
 import { compileShader } from '../core/style/shader-compiler';
 import { parseStyleDefinition } from '../core/style/parser';
 import Expression from '../core/style/expressions/expression';
+import Float from '../core/style/expressions/float';
 import CartoValidationError from './error-handling/carto-validation-error';
 
 
@@ -311,13 +312,17 @@ export default class Style {
         if (!(styleSpec.color instanceof Expression)) {
             throw new CartoValidationError('style', 'nonValidExpression[color]');
         }
-        if (!(styleSpec.width instanceof Expression)) {
-            throw new CartoValidationError('style', 'nonValidExpression[width]');
-        }
         if (!(styleSpec.strokeColor instanceof Expression)) {
             throw new CartoValidationError('style', 'nonValidExpression[strokeColor]');
         }
-        if (!(styleSpec.strokeWidth instanceof Expression)) {
+        if (util.isNumber(styleSpec.width)) {
+            styleSpec.width = new Float(styleSpec.width);
+        } else if (!(styleSpec.width instanceof Expression)) {
+            throw new CartoValidationError('style', 'nonValidExpression[width]');
+        }
+        if (util.isNumber(styleSpec.strokeWidth)) {
+            styleSpec.strokeWidth = new Float(styleSpec.strokeWidth);
+        } else if (!(styleSpec.strokeWidth instanceof Expression)) {
             throw new CartoValidationError('style', 'nonValidExpression[strokeWidth]');
         }
         if (!(styleSpec.order instanceof Expression)) {

--- a/src/core/style/expressions/utils.js
+++ b/src/core/style/expressions/utils.js
@@ -1,5 +1,4 @@
 import { float, category, time } from '../functions';
-import Expression from './expression';
 
 export const DEFAULT = undefined;
 
@@ -13,9 +12,6 @@ export function implicitCast(value) {
             return time(new Date(value));
         }
         return category(value);
-    }
-    if (!(value instanceof Expression) && value.type !== 'paletteGenerator' && value.type !== 'float') {
-        throw new Error('value cannot be casted');
     }
     return value;
 }

--- a/test/unit/api/style.test.js
+++ b/test/unit/api/style.test.js
@@ -5,33 +5,33 @@ describe('api/style', () => {
 
     describe('constructor', () => {
         describe('when parameter is a styleSpec object', () => {
-            xit('should set default style values when no parameters are given', () => {
+            it('should set default style values when no parameters are given', () => {
                 const actual = new Style();
 
                 // Check returned object inherits from Style
                 expect(actual).toEqual(jasmine.any(Style));
                 // Check returned object properties
                 expect(actual.getResolution()).toEqual(1);
-                expect(actual.getColor()).toEqual(s.rgba(0, 1, 0, 0.5));
-                expect(actual.getWidth()).toEqual(s.float(5));
-                expect(actual.getStrokeColor()).toEqual(s.rgba(0, 1, 0, 0.5));
-                expect(actual.getStrokeWidth()).toEqual(s.float(0));
-                expect(actual.getOrder()).toEqual(s.noOrder());
+                expect(actual.getColor().expr).toEqual(s.rgba(0, 1, 0, 0.5).expr);
+                expect(actual.getWidth().expr).toEqual(s.float(5).expr);
+                expect(actual.getStrokeColor().expr).toEqual(s.rgba(0, 1, 0, 0.5).expr);
+                expect(actual.getStrokeWidth().expr).toEqual(s.float(0).expr);
+                expect(actual.getOrder().expr).toEqual(s.noOrder().expr);
             });
 
-            xit('should set default style values when an empty object is given', () => {
+            it('should set default style values when an empty object is given', () => {
                 const actual = new Style({});
 
                 expect(actual).toEqual(jasmine.any(Style));
                 expect(actual.getResolution()).toEqual(1);
-                expect(actual.getColor()).toEqual(s.rgba(0, 1, 0, 0.5));
-                expect(actual.getWidth()).toEqual(s.float(5));
-                expect(actual.getStrokeColor()).toEqual(s.rgba(0, 1, 0, 0.5));
-                expect(actual.getStrokeWidth()).toEqual(s.float(0));
-                expect(actual.getOrder()).toEqual(s.noOrder());
+                expect(actual.getColor().expr).toEqual(s.rgba(0, 1, 0, 0.5).expr);
+                expect(actual.getWidth().expr).toEqual(s.float(5).expr);
+                expect(actual.getStrokeColor().expr).toEqual(s.rgba(0, 1, 0, 0.5).expr);
+                expect(actual.getStrokeWidth().expr).toEqual(s.float(0).expr);
+                expect(actual.getOrder().expr).toEqual(s.noOrder().expr);
             });
 
-            xit('should set the style properties defined in the styleSpec object', () => {
+            it('should set the style properties defined in the styleSpec object', () => {
                 const styleSpec = {
                     resolution: 2,
                     color: s.rgba(1, 0, 0, 1),
@@ -44,11 +44,22 @@ describe('api/style', () => {
 
                 expect(actual).toEqual(jasmine.any(Style));
                 expect(actual.getResolution()).toEqual(2);
-                expect(actual.getColor()).toEqual(s.rgba(1, 0, 0, 1));
-                expect(actual.getWidth()).toEqual(s.float(10));
-                expect(actual.getStrokeColor()).toEqual(s.rgba(0, 0, 1, 1));
-                expect(actual.getStrokeWidth()).toEqual(s.float(15));
-                expect(actual.getOrder()).toEqual(s.asc(s.width()));
+                expect(actual.getColor().expr).toEqual(s.rgba(1, 0, 0, 1).expr);
+                expect(actual.getWidth().expr).toEqual(s.float(10).expr);
+                expect(actual.getStrokeColor().expr).toEqual(s.rgba(0, 0, 1, 1).expr);
+                expect(actual.getStrokeWidth().expr).toEqual(s.float(15).expr);
+                expect(actual.getOrder().expr).toEqual(s.asc(s.width()).expr);
+            });
+            
+            it('should allow the style properties `width` and `strokeWidth` to be numbers', () => {
+                const actual = new Style({
+                    width: 1,
+                    strokeWidth: 10
+                });
+
+                expect(actual).toEqual(jasmine.any(Style));
+                expect(actual.getWidth().expr).toEqual(s.float(1).expr);
+                expect(actual.getStrokeWidth().expr).toEqual(s.float(10).expr);
             });
         });
 
@@ -79,7 +90,7 @@ describe('api/style', () => {
 
             it('should throw an error when width is not a valid expression', () => {
                 const styleSpec = {
-                    width: 10 // wrong type!
+                    width: true // wrong type!
                 };
                 expect(function () {
                     new Style(styleSpec);
@@ -97,7 +108,7 @@ describe('api/style', () => {
 
             it('should throw an error when strokeWidth is not a valid expression', () => {
                 const styleSpec = {
-                    strokeWidth: 5 // wrong type!
+                    strokeWidth: true // wrong type!
                 };
                 expect(function () {
                     new Style(styleSpec);


### PR DESCRIPTION
Related to: https://github.com/CartoDB/renderer-prototype/issues/165

- Allow numbers in width and strokeWidth properties
- Fix expressions/order example

