### PR TITLE
External race condition mitigation and atomic replacement

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -103,17 +103,15 @@ const auth = {
     user: 'dmanzanares',
     apiKey: 'YOUR_API_KEY'
 };
-const source = new carto.source.Dataset('ne_10m_populated_places_simple', auth);
-const style = new carto.Style();
-const layer = new carto.Layer('myCartoLayer', source, style);
 
+let layer = null;
 setInterval(() => {
-    document.getElementById('title').innerText = `Demo dataset  ~ ${layer.getNumFeatures()} features`;
-}, 500)
+    if (layer) {
+        document.getElementById('title').innerText = `Demo dataset  ~ ${layer.getNumFeatures()} features`;
+    }
+}, 500);
 
 map.on('load', () => {
-    layer.addTo(map, 'watername_ocean');
-
     let index = 0;//styles.length - 1;
 
     function handleError(error) {
@@ -224,24 +222,29 @@ map.on('load', () => {
         if (nosave) {
             location.hash = getConfig();
         }
-        layer.setStyle(new carto.Style()).then(() => {
-            const SourceClass = $('#dataset').val().toLowerCase().includes('select') ? carto.source.SQL : carto.source.Dataset;
-            layer.setSource(new SourceClass(
-                $('#dataset').val(),
-                {
-                    user: $('#user').val(),
-                    apiKey: 'YOUR_API_KEY'
-                },
-                {
-                    serverURL: $('#serverURL').val()
-                }
-            ));
-
-            localStorage.setItem('serverURL', $('#serverURL').val());
-            localStorage.setItem('user', $('#user').val());
-            localStorage.setItem('dataset', $('#dataset').val());
-            updateStyle();
-        });
+        const SourceClass = $('#dataset').val().toLowerCase().includes('select') ? carto.source.SQL : carto.source.Dataset;
+        const source = new SourceClass(
+            $('#dataset').val(),
+            {
+                user: $('#user').val(),
+                apiKey: 'YOUR_API_KEY'
+            },
+            {
+                serverURL: $('#serverURL').val()
+            }
+        );
+        const styleStr = document.getElementById('styleEntry').value;
+        const style = new carto.Style(styleStr);
+        if (!layer) {
+            layer = new carto.Layer('myCartoLayer', source, style);
+            layer.addTo(map, 'watername_ocean');
+        } else {
+            layer.setAtomicSourceStyle(source, style).then(() => {
+                localStorage.setItem('serverURL', $('#serverURL').val());
+                localStorage.setItem('user', $('#user').val());
+                localStorage.setItem('dataset', $('#dataset').val());
+            });
+        }
     };
 
 

--- a/example/index.js
+++ b/example/index.js
@@ -239,7 +239,7 @@ map.on('load', () => {
             layer = new carto.Layer('myCartoLayer', source, style);
             layer.addTo(map, 'watername_ocean');
         } else {
-            layer.setAtomicSourceStyle(source, style).then(() => {
+            layer.update(source, style).then(() => {
                 localStorage.setItem('serverURL', $('#serverURL').val());
                 localStorage.setItem('user', $('#user').val());
                 localStorage.setItem('dataset', $('#dataset').val());

--- a/src/api/layer.js
+++ b/src/api/layer.js
@@ -92,6 +92,36 @@ export default class Layer {
         this._listeners[eventType].splice(index, 1);
     }
 
+    async setAtomicSourceStyle(source, style) {
+        this._checkSource(source);
+        this._checkStyle(style);
+        this._atomicChangeUID = this._atomicChangeUID + 1 || 1;
+        const uid = this._atomicChangeUID;
+        await this._context;
+        const metadata = await source.requestMetadata(style);
+        if (this._atomicChangeUID > uid) {
+            throw new Error('Another atomic change was done before this one committed');
+        }
+
+        // Everything was ok => commit changes
+        this.metadata = metadata;
+
+        source.bindLayer(this._onDataframeAdded.bind(this), this._onDataFrameRemoved.bind(this), this._onDataLoaded.bind(this));
+        if (this._source && this._source !== source) {
+            this._source.free();
+        }
+        this._source = source;
+        this.requestData();
+
+        if (this._style) {
+            this._style.onChange(null);
+        }
+        this._style = style;
+        style.onChange(() => {
+            this._styleChanged(style);
+        });
+        this._compileShaders(style, metadata);
+    }
     /**
      * Set a new source for this layer.
      *
@@ -100,13 +130,24 @@ export default class Layer {
      * @instance
      * @api
      */
-    setSource(source) {
+    async setSource(source) {
         this._checkSource(source);
+        const style = this._style;
+        if (style) {
+            var metadata = await source.requestMetadata(style);
+        }
+        if (this._style !== style) {
+            throw new Error('A style change was made before the metadata was retrieved, therefore, metadata is stale and it cannot be longer consumed');
+        }
+        this.metadata = metadata;
         source.bindLayer(this._onDataframeAdded.bind(this), this._onDataFrameRemoved.bind(this), this._onDataLoaded.bind(this));
         if (this._source && this._source !== source) {
             this._source.free();
         }
         this._source = source;
+        if (style) {
+            this._styleChanged(style);
+        }
     }
 
     /**
@@ -282,7 +323,12 @@ export default class Layer {
     }
     async _styleChanged(style) {
         await this._context;
-        this.metadata = await this.requestMetadata(style);
+        const source = this._source;
+        const metadata = await source.requestMetadata(style);
+        if (this._source !== source) {
+            throw new Error('A source change was made before the metadata was retrieved, therefore, metadata is stale and it cannot be longer consumed');
+        }
+        this.metadata = metadata;
         this._compileShaders(style, this.metadata);
         return this.requestData();
     }

--- a/src/api/layer.js
+++ b/src/api/layer.js
@@ -92,7 +92,7 @@ export default class Layer {
         this._listeners[eventType].splice(index, 1);
     }
 
-    async setAtomicSourceStyle(source, style) {
+    async update(source, style) {
         this._checkSource(source);
         this._checkStyle(style);
         this._atomicChangeUID = this._atomicChangeUID + 1 || 1;


### PR DESCRIPTION
This PR adds:
 - Mitigation for race conditions triggered by concurrent calls to layer.setStyle() and layer.setSource().
   Multiple, close in time, calls to these functions generate race conditions as seen in examples/basics/change-source.html
 - Add support for atomicically change the source and the style. This makes the API easier when both things need to change, less error-prone, safer, and more performant.