### PR TITLE
Bugfix: non-active dataframes were being rendered

### DIFF
--- a/src/api/layer.js
+++ b/src/api/layer.js
@@ -51,7 +51,7 @@ export default class Layer {
         this._renderLayer = new RenderLayer();
         this.state = 'init';
         console.log('L', this);
-        
+
         this.setSource(source);
         this.setStyle(style);
 

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -220,7 +220,7 @@ export default class Windshaft {
 
     free() {
         this.cache.reset();
-        this._oldDataframes = [];        
+        this._oldDataframes = [];
     }
 
     _generateDataFrame(rs, geometry, properties, size, type) {

--- a/src/core/renderLayer.js
+++ b/src/core/renderLayer.js
@@ -22,6 +22,10 @@ export default class RenderLayer {
         this.dataframes = this.dataframes.filter(df => df !== dataframe);
     }
 
+    getActiveDataframes() {
+        return this.dataframes.filter(df => df.active);
+    }
+
     hasDataframes() {
         return this.dataframes.length > 0;
     }
@@ -39,6 +43,6 @@ export default class RenderLayer {
     freeDataframes() {
         this.dataframes.map(df => df.free());
         this.dataframes = [];
-        this.type = null;        
+        this.type = null;
     }
 }

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -148,7 +148,7 @@ class Renderer {
     }
 
     _computeDrawMetadata(renderLayer) {
-        const tiles = renderLayer.dataframes;
+        const tiles = renderLayer.getActiveDataframes();
         const style = renderLayer.style;
         const aspect = this.gl.canvas.clientWidth / this.gl.canvas.clientHeight;
         let drawMetadata = {
@@ -273,7 +273,7 @@ class Renderer {
         const aspect = gl.canvas.clientWidth / gl.canvas.clientHeight;
 
 
-        const tiles = renderLayer.dataframes;
+        const tiles = renderLayer.getActiveDataframes();
         const style = renderLayer.style;
 
         if (!tiles.length) {


### PR DESCRIPTION
![bug-tx](https://user-images.githubusercontent.com/1692175/37766161-5f3eacdc-2dc6-11e8-8aa6-1dbeb0f257ba.png)

No regression test since it would require E2E + simulate a zoom change