### PR TITLE
Add zoom.eval()

### DIFF
--- a/src/core/style/expressions/zoom.js
+++ b/src/core/style/expressions/zoom.js
@@ -7,14 +7,17 @@ export default class Zoom extends Expression {
      */
     constructor() {
         super({ zoom: float(0) });
+        this.type = 'float';
     }
     _compile(metadata) {
         super._compile(metadata);
-        this.type = 'float';
         super.inlineMaker = inline => inline.zoom;
     }
     _preDraw(drawMetadata, gl) {
         this.zoom.expr = drawMetadata.zoom;
         this.zoom._preDraw(drawMetadata, gl);
+    }
+    eval() {
+        return this.zoom.expr;
     }
 }

--- a/test/unit/core/style/expressions/zoom.test.js
+++ b/test/unit/core/style/expressions/zoom.test.js
@@ -1,0 +1,7 @@
+import { validateStaticType } from './utils';
+
+describe('src/core/style/expressions/zoom', () => {
+    describe('type', () => {
+        validateStaticType('zoom', [], 'float');
+    });
+});


### PR DESCRIPTION
This is required to use interactivity on styles with zoom() in their `width`