### PR TITLE
Fix osx bug

### DIFF
--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -263,13 +263,12 @@ class Renderer {
     renderLayer(renderLayer) {
         const tiles = renderLayer.getActiveDataframes();
         const style = renderLayer.style;
+        const gl = this.gl;
+        const aspect = this.getAspect();
 
         if (!tiles.length) {
             return;
         }
-
-        const gl = this.gl;
-        const aspect = this.getAspect();
 
         gl.enable(gl.CULL_FACE);
 
@@ -324,13 +323,14 @@ class Renderer {
         gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
         if (renderLayer.type != 'point') {
+            const antialiasingScale = (window.devicePixelRatio || 1) >= 2 ? 1 : 2;
             gl.bindFramebuffer(gl.FRAMEBUFFER, this._AAFB);
             const [w, h] = [gl.drawingBufferWidth, gl.drawingBufferHeight];
 
             if (w != this._width || h != this._height) {
                 gl.bindTexture(gl.TEXTURE_2D, this._AATex);
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA,
-                    w * 2, h * 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+                    w * antialiasingScale, h * antialiasingScale, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
@@ -339,7 +339,7 @@ class Renderer {
 
                 [this._width, this._height] = [w, h];
             }
-            gl.viewport(0, 0, w * 2, h * 2);
+            gl.viewport(0, 0, w * antialiasingScale, h * antialiasingScale);
             gl.clear(gl.COLOR_BUFFER_BIT);
         }
 

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -371,6 +371,8 @@ class Renderer {
                 s * (this._center.y - tile.center.y));
             if (tile.type == 'line') {
                 gl.uniform2f(renderer.normalScale, 1 / gl.canvas.clientWidth, 1 / gl.canvas.clientHeight);
+            } else if (tile.type == 'point') {
+                gl.uniform1f(renderer.devicePixelRatio, window.devicePixelRatio || 1);
             }
 
             tile.vertexScale = [(s / aspect) * tile.scale, s * tile.scale];

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -261,24 +261,15 @@ class Renderer {
     }
 
     renderLayer(renderLayer) {
-        const gl = this.gl;
-
-        const width = gl.canvas.clientWidth;
-        const height = gl.canvas.clientHeight;
-        if (gl.canvas.width != width ||
-            gl.canvas.height != height) {
-            gl.canvas.width = width;
-            gl.canvas.height = height;
-        }
-        const aspect = gl.canvas.clientWidth / gl.canvas.clientHeight;
-
-
         const tiles = renderLayer.getActiveDataframes();
         const style = renderLayer.style;
 
         if (!tiles.length) {
             return;
         }
+
+        const gl = this.gl;
+        const aspect = gl.canvas.clientWidth / gl.canvas.clientHeight;
 
         gl.enable(gl.CULL_FACE);
 

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -142,7 +142,7 @@ class Renderer {
 
     getAspect() {
         if (this.gl) {
-            return this.gl.canvas.clientWidth / this.gl.canvas.clientHeight;
+            return this.gl.canvas.width / this.gl.canvas.height;
         }
         return 1;
     }
@@ -150,7 +150,7 @@ class Renderer {
     _computeDrawMetadata(renderLayer) {
         const tiles = renderLayer.getActiveDataframes();
         const style = renderLayer.style;
-        const aspect = this.gl.canvas.clientWidth / this.gl.canvas.clientHeight;
+        const aspect = this.getAspect();
         let drawMetadata = {
             freeTexUnit: 4,
             zoom: 1. / this._zoom,
@@ -269,7 +269,7 @@ class Renderer {
         }
 
         const gl = this.gl;
-        const aspect = gl.canvas.clientWidth / gl.canvas.clientHeight;
+        const aspect = this.getAspect();
 
         gl.enable(gl.CULL_FACE);
 

--- a/src/core/shaders/index.js
+++ b/src/core/shaders/index.js
@@ -61,6 +61,7 @@ class Point {
         this.orderMinWidth = gl.getUniformLocation(this.program, 'orderMinWidth');
         this.orderMaxWidth = gl.getUniformLocation(this.program, 'orderMaxWidth');
         this.filterTexture = gl.getUniformLocation(this.program, 'filterTex');
+        this.devicePixelRatio = gl.getUniformLocation(this.program, 'devicePixelRatio');
     }
 }
 class Tri {

--- a/src/core/shaders/renderer/point.js
+++ b/src/core/shaders/renderer/point.js
@@ -54,6 +54,7 @@ uniform vec2 vertexScale;
 uniform vec2 vertexOffset;
 uniform float orderMinWidth;
 uniform float orderMaxWidth;
+uniform float devicePixelRatio;
 
 uniform sampler2D colorTex;
 uniform sampler2D widthTex;
@@ -85,7 +86,7 @@ void main(void) {
     if (fillScale==strokeScale){
         stroke.a=0.;
     }
-    gl_PointSize = size+2.;
+    gl_PointSize = size * devicePixelRatio + 2.;
     dp = 1.0/(size+1.);
     sizeNormalizer = (size+1.)/(size);
 


### PR DESCRIPTION
Fixes #233
---- 

When the renderer had no tiles an early return was forced.

This return happened after changing the canvas size causing an inconsistent state that completely crashed the system.


I think we should try to isolate the bug with less code as possible just for fun.