### PR TITLE
Disables drag to rotate handling from examples

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -97,6 +97,7 @@ var map = new mapboxgl.Map({
     style: BASEMAPS[basemap], // stylesheet location
     center: [2.17, 41.38], // starting position [lng, lat]
     zoom: 13, // starting zoom,
+    dragRotate: false, // disable drag to rotate handling
 });
 
 const auth = {

--- a/examples/basics/change-source.html
+++ b/examples/basics/change-source.html
@@ -73,7 +73,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/basics/change-style.html
+++ b/examples/basics/change-style.html
@@ -73,7 +73,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/basics/multi-layer.html
+++ b/examples/basics/multi-layer.html
@@ -29,7 +29,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 40],
-      zoom: 4
+      zoom: 4,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/basics/single-layer.html
+++ b/examples/basics/single-layer.html
@@ -29,7 +29,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/animation.html
+++ b/examples/expressions/animation.html
@@ -29,7 +29,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
       center: [0, 30],
-      zoom: 1
+      zoom: 1,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/color.html
+++ b/examples/expressions/color.html
@@ -77,7 +77,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/default.html
+++ b/examples/expressions/default.html
@@ -29,7 +29,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/filter.html
+++ b/examples/expressions/filter.html
@@ -29,7 +29,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/order.html
+++ b/examples/expressions/order.html
@@ -73,7 +73,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [2.1734, 41.3851],
-      zoom: 14
+      zoom: 14,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/ramp-category.html
+++ b/examples/expressions/ramp-category.html
@@ -73,7 +73,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
       center: [2.1734, 41.3851],
-      zoom: 12
+      zoom: 12,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/ramp-numeric.html
+++ b/examples/expressions/ramp-numeric.html
@@ -73,7 +73,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
       center: [-100.3710, 38.4793],
-      zoom: 4
+      zoom: 4,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/torque.html
+++ b/examples/expressions/torque.html
@@ -29,7 +29,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
       center: [0, 0],
-      zoom: 8
+      zoom: 8,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/expressions/viewport.html
+++ b/examples/expressions/viewport.html
@@ -29,7 +29,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
       center: [2.1734, 41.3851],
-      zoom: 12
+      zoom: 12,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/lines/feature-click.html
+++ b/examples/interactivity/lines/feature-click.html
@@ -65,7 +65,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/lines/feature-enter-leave.html
+++ b/examples/interactivity/lines/feature-enter-leave.html
@@ -62,7 +62,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/lines/feature-hover.html
+++ b/examples/interactivity/lines/feature-hover.html
@@ -65,7 +65,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/points/feature-click.html
+++ b/examples/interactivity/points/feature-click.html
@@ -65,7 +65,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/points/feature-enter-leave.html
+++ b/examples/interactivity/points/feature-enter-leave.html
@@ -62,7 +62,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/points/feature-hover.html
+++ b/examples/interactivity/points/feature-hover.html
@@ -65,7 +65,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/polygons/feature-click.html
+++ b/examples/interactivity/polygons/feature-click.html
@@ -65,7 +65,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/polygons/feature-enter-leave.html
+++ b/examples/interactivity/polygons/feature-enter-leave.html
@@ -62,7 +62,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/interactivity/polygons/feature-hover.html
+++ b/examples/interactivity/polygons/feature-hover.html
@@ -65,7 +65,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/misc/edit-sql-expressions.html
+++ b/examples/misc/edit-sql-expressions.html
@@ -132,7 +132,8 @@ filter: $pop_max > 10000
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({

--- a/examples/misc/geojson-viewer.html
+++ b/examples/misc/geojson-viewer.html
@@ -29,7 +29,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     const data = {

--- a/examples/misc/populated-places.html
+++ b/examples/misc/populated-places.html
@@ -73,7 +73,8 @@
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
       center: [0, 30],
-      zoom: 2
+      zoom: 2,
+      dragRotate: false,
     });
 
     carto.setDefaultAuth({


### PR DESCRIPTION
We don't support bearing/pitch, so better disabling it from Mapbox GL examples.