### PR TITLE
Fix null category management

### DIFF
--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -137,9 +137,16 @@ export default class Windshaft {
         return !!this.metadata;
     }
 
-    _getCategoryIDFromString(category) {
+    _getCategoryIDFromString(category, readonly = true) {
+        if (category === undefined){
+            category = 'null';
+        }
         if (this._categoryStringToIDMap[category] !== undefined) {
             return this._categoryStringToIDMap[category];
+        }
+        if (readonly){
+            console.warn(`category ${category} not present in metadata`);
+            return -1;
         }
         this._categoryStringToIDMap[category] = this._numCategories;
         this._numCategories++;
@@ -511,7 +518,7 @@ export default class Windshaft {
         const categoryIDs = {};
         categories.map((name, index) => {
             const t = categoriesTypes[index];
-            t.categoryNames.map(name => categoryIDs[name] = this._getCategoryIDFromString(name));
+            t.categoryNames.map(name => categoryIDs[name] = this._getCategoryIDFromString(name, false));
             columns.push(t);
         });
         const metadata = new Metadata(categoryIDs, columns, featureCount, sample);

--- a/test/unit/client/windshaft.test.js
+++ b/test/unit/client/windshaft.test.js
@@ -1,0 +1,20 @@
+import Windshaft from '../../../src/client/windshaft';
+
+describe('src/client/windshaft', () => {
+    describe('_getCategoryIDFromString', () => {
+        it('should add categories', () => {
+            const w = new Windshaft(null);
+            w._getCategoryIDFromString('cat1', false);
+            w._getCategoryIDFromString('cat2', false);
+            expect(w._getCategoryIDFromString('cat1')).toEqual(0);
+            expect(w._getCategoryIDFromString('cat2')).toEqual(1);
+        });
+        it('should manage null categories', () => {
+            const w = new Windshaft(null);
+            w._getCategoryIDFromString('cat1', false);
+            w._getCategoryIDFromString('cat2', false);
+            w._getCategoryIDFromString('null', false);
+            expect(w._getCategoryIDFromString(undefined)).toEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
Fix for https://github.com/CartoDB/renderer-prototype/issues/132

Manually tested with SF lines dataset

~Waiting to get the original dataset to check that this solves it.~ Original dataset couldn't be found

~TODO: add unit test~