### PR TITLE
Fix agg as viewport/global/quantiles params

### DIFF
--- a/src/client/windshaft-filtering.js
+++ b/src/client/windshaft-filtering.js
@@ -167,7 +167,7 @@ class AggregationFiltering {
         if (f instanceof Max || f instanceof Min || f instanceof Avg || f instanceof Sum || f instanceof Mode) {
             let p = this._property(f.property);
             if (p) {
-                p.property = schema.column.aggColumn(p.property, f._aggName);
+                p.property = schema.column.aggColumn(p.property, f.aggName());
                 return p;
             }
         }

--- a/src/client/windshaft-filtering.js
+++ b/src/client/windshaft-filtering.js
@@ -167,7 +167,7 @@ class AggregationFiltering {
         if (f instanceof Max || f instanceof Min || f instanceof Avg || f instanceof Sum || f instanceof Mode) {
             let p = this._property(f.property);
             if (p) {
-                p.property = schema.column.aggColumn(p.property, f.aggName());
+                p.property = schema.column.aggColumn(p.property, f.aggName);
                 return p;
             }
         }

--- a/src/core/dataframe.js
+++ b/src/core/dataframe.js
@@ -188,24 +188,21 @@ export default class Dataframe {
     }
 
     _addFeatureToArray(featureIndex, features) {
-        const properties = this._getPropertiesOf(featureIndex);
-        features.push({
-            id: properties.cartodb_id,
-            properties
-        });
-    }
-
-    _getPropertiesOf(featureID) {
+        let id = '';
         const properties = {};
         Object.keys(this.properties).map(propertyName => {
-            let prop = this.properties[propertyName][featureID];
-            const column = this.metadata.columns.find(c => c.name == propertyName);
-            if (column.type == 'category') {
-                prop = column.categoryNames[prop];
+            let prop = this.properties[propertyName][featureIndex];
+            if (propertyName === 'cartodb_id') {
+                id = prop;
+            } else {
+                const column = this.metadata.columns.find(c => c.name == propertyName);
+                if (column && column.type == 'category') {
+                    prop = column.categoryNames[prop];
+                }
+                properties[propertyName] = prop;
             }
-            properties[propertyName] = prop;
         });
-        return properties;
+        features.push({ id, properties });
     }
 
     _genDataframePropertyTextures() {

--- a/src/core/style/expressions/aggregation.js
+++ b/src/core/style/expressions/aggregation.js
@@ -14,7 +14,7 @@ function genAggregationOp(aggName, aggType) {
     return class AggregationOperation extends Expression {
         constructor(property) {
             checkInstance(aggName, 'property', 0, Property, property);
-            super({ property: property });
+            super({ property });
             this._aggName = aggName;
             this.type = aggType;
         }
@@ -27,6 +27,9 @@ function genAggregationOp(aggName, aggType) {
         get numCategories() {
             return this.property.numCategories;
         }
+        eval(feature) {
+            return feature[schema.column.aggColumn(this.property.name, aggName)];
+        }
         //Override super methods, we don't want to let the property use the raw column, we must use the agg suffixed one
         _compile(metadata) {
             super._compile(metadata);
@@ -37,9 +40,6 @@ function genAggregationOp(aggName, aggType) {
                 preface: '',
                 inline: `${getGLSLforProperty(schema.column.aggColumn(this.property.name, aggName))}`
             };
-        }
-        eval(feature) {
-            return feature[schema.column.aggColumn(this.property.name, aggName)];
         }
         _postShaderCompile() { }
         _getMinimumNeededSchema() {

--- a/src/core/style/expressions/aggregation.js
+++ b/src/core/style/expressions/aggregation.js
@@ -21,6 +21,9 @@ function genAggregationOp(aggName, aggType) {
         get name() {
             return this.property.name;
         }
+        get aggName() {
+            return this._aggName;
+        }
         get numCategories() {
             return this.property.numCategories;
         }

--- a/src/core/style/expressions/ordering.js
+++ b/src/core/style/expressions/ordering.js
@@ -19,7 +19,7 @@ export class Asc extends Expression {
 export class Desc extends Expression {
     constructor(by) {
         super({});
-        checkInstance('asc', 'by', 0, Width, by);
+        checkInstance('desc', 'by', 0, Width, by);
         this.type = 'orderer';
     }
 }

--- a/src/core/style/expressions/quantiles.js
+++ b/src/core/style/expressions/quantiles.js
@@ -2,13 +2,14 @@ import Expression from './expression';
 import { float } from '../functions';
 import { checkNumber, checkInstance, checkType } from './utils';
 import Property from './property';
+import * as schema from '../../schema';
 
 let quantilesUID = 0;
 
 function genQuantiles(global) {
     return class Quantiles extends Expression {
         constructor(input, buckets) {
-            checkInstance('quantiles', 'input', 0, Property, input);
+            checkInstance('quantiles', 'input', 0, Property, input && (input.property || input));
             checkNumber('quantiles', 'buckets', 1, buckets);
 
             let children = {
@@ -26,6 +27,14 @@ function genQuantiles(global) {
             this.breakpoints = breakpoints;
             this.type = 'category';
         }
+        eval(feature) {
+            const input = this.input.eval(feature);
+            const q = this.breakpoints.findIndex(br => input <= br);
+            return q;
+        }
+        getBreakpointList() {
+            return this.breakpoints.map(br => br.expr);
+        }
         _compile(metadata) {
             super._compile(metadata);
             checkType('quantiles', 'input', 0, 'float', this.input);
@@ -39,7 +48,7 @@ function genQuantiles(global) {
             }
         }
         _getDrawMetadataRequirements() {
-            return { columns: [this.input.name] };
+            return { columns: [this._getColumnName()] };
         }
         _applyToShaderSource(uniformIDMaker, getGLSLforProperty) {
             const childSources = this.childrenNames.map(name => this[name]._applyToShaderSource(uniformIDMaker, getGLSLforProperty));
@@ -60,13 +69,9 @@ function genQuantiles(global) {
                 inline: `${funcName}(${childInlines.input})`
             };
         }
-        eval(feature) {
-            const input = this.input.eval(feature);
-            const q = this.breakpoints.findIndex(br => input <= br);
-            return q;
-        }
         _preDraw(drawMetadata, gl) {
-            const column = drawMetadata.columns.find(c => c.name == this.input.name);
+            const name = this._getColumnName();
+            const column = drawMetadata.columns.find(c => c.name == name);
             let i = 0;
             const total = column.accumHistogram[column.histogramBuckets - 1];
             const r = Math.random();
@@ -90,8 +95,12 @@ function genQuantiles(global) {
             }
             super._preDraw(drawMetadata, gl);
         }
-        getBreakpointList() {
-            return this.breakpoints.map(br => br.expr);
+        _getColumnName() {
+            if (this.property.aggName) {
+                // Property has aggregation
+                return schema.column.aggColumn(this.property.name, this.property.aggName());
+            }
+            return this.input.name;
         }
     };
 }

--- a/src/core/style/expressions/quantiles.js
+++ b/src/core/style/expressions/quantiles.js
@@ -96,9 +96,9 @@ function genQuantiles(global) {
             super._preDraw(drawMetadata, gl);
         }
         _getColumnName() {
-            if (this.property.aggName) {
+            if (this.input.aggName) {
                 // Property has aggregation
-                return schema.column.aggColumn(this.property.name, this.property.aggName());
+                return schema.column.aggColumn(this.input.name, this.input.aggName);
             }
             return this.input.name;
         }

--- a/src/core/style/expressions/viewportAggregation.js
+++ b/src/core/style/expressions/viewportAggregation.js
@@ -1,6 +1,6 @@
 import Expression from './expression';
-import * as schema from '../../schema';
 import { float } from '../functions';
+import * as schema from '../../schema';
 
 export const ViewportMax = generateAggregattion('max');
 export const ViewportMin = generateAggregattion('min');
@@ -109,8 +109,8 @@ function generatePercentile(global) {
             }
         }
         _preDraw(drawMetadata, gl) {
+            const name = this._getColumnName();
             if (!global) {
-                const name = this._getColumnName();
                 const column = drawMetadata.columns.find(c => c.name === name);
                 const total = column.accumHistogram[column.histogramBuckets - 1];
                 // TODO OPT: this could be faster with binary search
@@ -122,7 +122,6 @@ function generatePercentile(global) {
                 const br = i / column.histogramBuckets * (column.max - column.min) + column.min;
                 this.value.expr = br;
             }
-
             if (Math.random() > 0.99) {
                 console.log(`percentile${this.percentile}`, name, this.value.expr);
             }

--- a/src/core/style/expressions/viewportAggregation.js
+++ b/src/core/style/expressions/viewportAggregation.js
@@ -64,7 +64,7 @@ function generateAggregattion(metadataPropertyName, global) {
         _getColumnName() {
             if (this.property.aggName) {
                 // Property has aggregation
-                return schema.column.aggColumn(this.property.name, this.property.aggName());
+                return schema.column.aggColumn(this.property.name, this.property.aggName);
             }
             return this.property.name;
         }
@@ -133,7 +133,7 @@ function generatePercentile(global) {
         _getColumnName() {
             if (this.property.aggName) {
                 // Property has aggregation
-                return schema.column.aggColumn(this.property.name, this.property.aggName());
+                return schema.column.aggColumn(this.property.name, this.property.aggName);
             }
             return this.property.name;
         }

--- a/src/core/style/expressions/viewportAggregation.js
+++ b/src/core/style/expressions/viewportAggregation.js
@@ -1,4 +1,5 @@
 import Expression from './expression';
+import * as schema from '../../schema';
 import { float } from '../functions';
 
 export const ViewportMax = generateAggregattion('max');
@@ -41,23 +42,31 @@ function generateAggregattion(metadataPropertyName, global) {
         }
         _getDrawMetadataRequirements() {
             if (!global) {
-                return { columns: [this.property.name] };
+                return { columns: [this._getColumnName()] };
             } else {
                 return { columns: [] };
             }
         }
         _preDraw(drawMetadata, gl) {
-            const column = drawMetadata.columns.find(c => c.name == this.property.name);
+            const name = this._getColumnName();
+            const column = drawMetadata.columns.find(c => c.name === name);
             if (!global) {
                 this.value.expr = column[metadataPropertyName];
             }
             if (Math.random() > 0.999) {
-                console.log(metadataPropertyName, this.property.name, this.value.expr);
+                console.log(metadataPropertyName, name, this.value.expr);
             }
             this.value._preDraw(drawMetadata, gl);
         }
         eval() {
             return this.value.expr;
+        }
+        _getColumnName() {
+            if (this.property.aggName) {
+                // Property has aggregation
+                return schema.column.aggColumn(this.property.name, this.property.aggName());
+            }
+            return this.property.name;
         }
     };
 }

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -70,7 +70,7 @@ describe('Interactivity', () => {
                     expect(event.features[0].style.color.blendTo).toBeDefined();
                     expect(event.features[0].style.color.reset).toBeDefined();
                     expect(event.features[0].style.reset).toBeDefined();
-                    expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { cartodb_id: 0 }, style: jasmine.any(Object) });
+                    expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { }, style: jasmine.any(Object) });
                     done();
                 });
                 layer.on('loaded', () => {
@@ -105,8 +105,8 @@ describe('Interactivity', () => {
                     layer = new carto.Layer('layer', source, new carto.Style());
                     interactivity = new carto.Interactivity(layer);
                     interactivity.on('featureClick', event => {
-                        expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { cartodb_id: 0 }, style: jasmine.any(Object) });
-                        expect(event.features[1]).toEqual({ id: 1, layerId: 'layer', properties: { cartodb_id: 1 }, style: jasmine.any(Object) });
+                        expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { }, style: jasmine.any(Object) });
+                        expect(event.features[1]).toEqual({ id: 1, layerId: 'layer', properties: { }, style: jasmine.any(Object) });
                         done();
                     });
                     layer.on('loaded', () => {
@@ -135,7 +135,7 @@ describe('Interactivity', () => {
                     it('should fire a featureClickOut event with a features list containing the previously clicked feature', done => {
                         interactivity = new carto.Interactivity(layer);
                         interactivity.on('featureClickOut', event => {
-                            expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { cartodb_id: 0 }, style: jasmine.any(Object) });
+                            expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { }, style: jasmine.any(Object) });
                             done();
                         });
                         layer.on('loaded', () => {
@@ -159,7 +159,7 @@ describe('Interactivity', () => {
                 it('should fire a featureHover event with a features list containing the entered feature', done => {
                     interactivity = new carto.Interactivity(layer);
                     interactivity.on('featureHover', event => {
-                        expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { cartodb_id: 0 }, style: jasmine.any(Object) });
+                        expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { }, style: jasmine.any(Object) });
                         done();
                     });
                     layer.on('loaded', () => {
@@ -172,7 +172,7 @@ describe('Interactivity', () => {
                 it('should fire a featureEnter event with a features list containing the entered feature', done => {
                     interactivity = new carto.Interactivity(layer);
                     interactivity.on('featureEnter', event => {
-                        expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { cartodb_id: 0 }, style: jasmine.any(Object) });
+                        expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { }, style: jasmine.any(Object) });
                         done();
                     });
                     layer.on('loaded', () => {
@@ -222,7 +222,7 @@ describe('Interactivity', () => {
                         // Move mouse inside a feature
                         map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
                         interactivity.on('featureLeave', event => {
-                            expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { cartodb_id: 0 }, style: jasmine.any(Object) });
+                            expect(event.features[0]).toEqual({ id: 0, layerId: 'layer', properties: { }, style: jasmine.any(Object) });
                             done();
                         });
                         // Move mouse outside the feature

--- a/test/unit/api/style.test.js
+++ b/test/unit/api/style.test.js
@@ -153,7 +153,7 @@ describe('api/style', () => {
         });
 
         describe('when parameter is a string', () => {
-            xit('should set the style properties defined in the string', () => {
+            it('should set the style properties defined in the string', () => {
                 const styleSpec = `
                     color: rgba(1, 0, 0, 1),
                     width: float(10),
@@ -165,11 +165,11 @@ describe('api/style', () => {
 
                 expect(actual).toEqual(jasmine.any(Style));
                 expect(actual.getResolution()).toEqual(1);
-                expect(actual.getColor()).toEqual(s.rgba(1, 0, 0, 1));
-                expect(actual.getWidth()).toEqual(s.float(10));
-                expect(actual.getStrokeColor()).toEqual(s.rgba(0, 0, 1, 1));
-                expect(actual.getStrokeWidth()).toEqual(s.float(15));
-                expect(actual.getOrder()).toEqual(s.asc(s.width()));
+                expect(actual.getColor().expr).toEqual(s.rgba(1, 0, 0, 1).expr);
+                expect(actual.getWidth().expr).toEqual(s.float(10).expr);
+                expect(actual.getStrokeColor().expr).toEqual(s.rgba(0, 0, 1, 1).expr);
+                expect(actual.getStrokeWidth().expr).toEqual(s.float(15).expr);
+                expect(actual.getOrder().expr).toEqual(s.asc(s.width()).expr);
             });
         });
     });

--- a/test/unit/api/style.test.js
+++ b/test/unit/api/style.test.js
@@ -12,10 +12,10 @@ describe('api/style', () => {
                 expect(actual).toEqual(jasmine.any(Style));
                 // Check returned object properties
                 expect(actual.getResolution()).toEqual(1);
-                expect(actual.getColor().expr).toEqual(s.rgba(0, 1, 0, 0.5).expr);
-                expect(actual.getWidth().expr).toEqual(s.float(5).expr);
-                expect(actual.getStrokeColor().expr).toEqual(s.rgba(0, 1, 0, 0.5).expr);
-                expect(actual.getStrokeWidth().expr).toEqual(s.float(0).expr);
+                expect(actual.getColor().eval()).toEqual(s.rgba(0, 255, 0, 0.5).eval());
+                expect(actual.getWidth().eval()).toEqual(s.float(5).eval());
+                expect(actual.getStrokeColor().eval()).toEqual(s.rgba(0, 255, 0, 0.5).eval());
+                expect(actual.getStrokeWidth().eval()).toEqual(s.float(0).eval());
                 expect(actual.getOrder().expr).toEqual(s.noOrder().expr);
             });
 
@@ -24,19 +24,19 @@ describe('api/style', () => {
 
                 expect(actual).toEqual(jasmine.any(Style));
                 expect(actual.getResolution()).toEqual(1);
-                expect(actual.getColor().expr).toEqual(s.rgba(0, 1, 0, 0.5).expr);
-                expect(actual.getWidth().expr).toEqual(s.float(5).expr);
-                expect(actual.getStrokeColor().expr).toEqual(s.rgba(0, 1, 0, 0.5).expr);
-                expect(actual.getStrokeWidth().expr).toEqual(s.float(0).expr);
+                expect(actual.getColor().eval()).toEqual(s.rgba(0, 255, 0, 0.5).eval());
+                expect(actual.getWidth().eval()).toEqual(s.float(5).eval());
+                expect(actual.getStrokeColor().eval()).toEqual(s.rgba(0, 255, 0, 0.5).eval());
+                expect(actual.getStrokeWidth().eval()).toEqual(s.float(0).eval());
                 expect(actual.getOrder().expr).toEqual(s.noOrder().expr);
             });
 
             it('should set the style properties defined in the styleSpec object', () => {
                 const styleSpec = {
                     resolution: 2,
-                    color: s.rgba(1, 0, 0, 1),
+                    color: s.rgba(255, 0, 0, 1),
                     width: s.float(10),
-                    strokeColor: s.rgba(0, 0, 1, 1),
+                    strokeColor: s.rgba(0, 0, 255, 1),
                     strokeWidth: s.float(15),
                     order: s.asc(s.width())
                 };
@@ -44,10 +44,10 @@ describe('api/style', () => {
 
                 expect(actual).toEqual(jasmine.any(Style));
                 expect(actual.getResolution()).toEqual(2);
-                expect(actual.getColor().expr).toEqual(s.rgba(1, 0, 0, 1).expr);
-                expect(actual.getWidth().expr).toEqual(s.float(10).expr);
-                expect(actual.getStrokeColor().expr).toEqual(s.rgba(0, 0, 1, 1).expr);
-                expect(actual.getStrokeWidth().expr).toEqual(s.float(15).expr);
+                expect(actual.getColor().eval()).toEqual(s.rgba(255, 0, 0, 1).eval());
+                expect(actual.getWidth().eval()).toEqual(s.float(10).eval());
+                expect(actual.getStrokeColor().eval()).toEqual(s.rgba(0, 0, 255, 1).eval());
+                expect(actual.getStrokeWidth().eval()).toEqual(s.float(15).eval());
                 expect(actual.getOrder().expr).toEqual(s.asc(s.width()).expr);
             });
 
@@ -58,8 +58,8 @@ describe('api/style', () => {
                 });
 
                 expect(actual).toEqual(jasmine.any(Style));
-                expect(actual.getWidth().expr).toEqual(s.float(1).expr);
-                expect(actual.getStrokeWidth().expr).toEqual(s.float(10).expr);
+                expect(actual.getWidth().eval()).toEqual(s.float(1).eval());
+                expect(actual.getStrokeWidth().eval()).toEqual(s.float(10).eval());
             });
         });
 
@@ -155,20 +155,20 @@ describe('api/style', () => {
         describe('when parameter is a string', () => {
             it('should set the style properties defined in the string', () => {
                 const styleSpec = `
-                    color: rgba(1, 0, 0, 1),
-                    width: float(10),
-                    strokeColor: rgba(0, 0, 1, 1),
-                    strokeWidth: float(15),
+                    color: rgba(255, 0, 0, 1)
+                    width: float(10)
+                    strokeColor: rgba(0, 0, 255, 1)
+                    strokeWidth: float(15)
                     order: asc(width())
                 `;
                 const actual = new Style(styleSpec);
 
                 expect(actual).toEqual(jasmine.any(Style));
                 expect(actual.getResolution()).toEqual(1);
-                expect(actual.getColor().expr).toEqual(s.rgba(1, 0, 0, 1).expr);
-                expect(actual.getWidth().expr).toEqual(s.float(10).expr);
-                expect(actual.getStrokeColor().expr).toEqual(s.rgba(0, 0, 1, 1).expr);
-                expect(actual.getStrokeWidth().expr).toEqual(s.float(15).expr);
+                expect(actual.getColor().eval()).toEqual(s.rgba(255, 0, 0, 1).eval());
+                expect(actual.getWidth().eval()).toEqual(s.float(10).eval());
+                expect(actual.getStrokeColor().eval()).toEqual(s.rgba(0, 0, 255, 1).eval());
+                expect(actual.getStrokeWidth().eval()).toEqual(s.float(15).eval());
                 expect(actual.getOrder().expr).toEqual(s.asc(s.width()).expr);
             });
         });

--- a/test/unit/core/dataframe.test.js
+++ b/test/unit/core/dataframe.test.js
@@ -28,8 +28,8 @@ describe('src/core/dataframe', () => {
                     }]
                 }
             });
-            const feature1 = { id: 0, properties: { cartodb_id: 0, id: 1 } };
-            const feature2 = { id: 1, properties: { cartodb_id: 1, id: 2 } };
+            const feature1 = { id: 0, properties: { id: 1 } };
+            const feature2 = { id: 1, properties: { id: 2 } };
             const style = {
                 getWidth: () => ({ eval: () => 0.5 }),
                 getStrokeWidth: () => ({ eval: () => 0.5 })
@@ -78,8 +78,7 @@ describe('src/core/dataframe', () => {
             const feature1 = {
                 id: 0,
                 properties: {
-                    numeric_prop: 1,
-                    cartodb_id: 0
+                    numeric_prop: 1
                 }
             };
             const style = {
@@ -136,8 +135,7 @@ describe('src/core/dataframe', () => {
             const feature1 = {
                 id: 0,
                 properties: {
-                    numeric_property: 0,
-                    cartodb_id: 0
+                    numeric_property: 0
                 }
             };
             it('should return an empty list when there are no features at the given position', () => {


### PR DESCRIPTION
This PR recovers some fixes implemented in the `source-columns-agg` branch that have value by itself out of the box:

- Fix using aggregations in viewport functions. Ex. `vieportMax(sum($prop))`
- Fix using aggregations in global functions. Ex. `globalAvg(sum($prop))`
- Fix using aggregations in quantiles function. Ex. `quantiles(avg($prop))` 
- Remove redundant `cartodb_id` property from `feature.properties` since it is the `feature.id`